### PR TITLE
Add v8 findrefs command

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -317,6 +317,9 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
                 "Print information about Node.js\n");
 
+  v8.AddCommand("findrefs", new llnode::FindReferencesCmd(),
+                "Find all the objects that refer to the specified object.\n");
+
   return true;
 }
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -419,8 +419,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
   // Walk all the properties in this object.
   // We only create strings for the field names that match the search
   // value.
-  std::vector<std::pair<v8::Value, v8::Value>> entries;
-  js_obj.Entries(entries, err);
+  std::vector<std::pair<v8::Value, v8::Value>> entries = js_obj.Entries(err);
   if (err.Success()) {
     for (auto entry : entries) {
       v8::Value v = entry.second;

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -34,6 +34,22 @@ class NodeInfoCmd : public CommandBase {
                  lldb::SBCommandReturnObject& result) override;
 };
 
+class FindReferencesCmd : public CommandBase {
+ public:
+  ~FindReferencesCmd() override{};
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+ private:
+  bool detailed_;
+
+  void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
+                 v8::Value& search_value, v8::Error& err);
+  void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
+                 v8::Value& search_value, v8::Error& err);
+};
+
 class MemoryVisitor {
  public:
   virtual ~MemoryVisitor(){};

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -44,10 +44,27 @@ class FindReferencesCmd : public CommandBase {
  private:
   bool detailed_;
 
-  void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
-                 v8::Value& search_value, v8::Error& err);
-  void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
-                 v8::Value& search_value, v8::Error& err);
+  class ObjectScanner {
+   public:
+    ~ObjectScanner(){};
+    virtual void PrintRefs(lldb::SBCommandReturnObject& result,
+                           v8::JSObject& js_obj, v8::Error& err){};
+    virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
+                           v8::Error& err){};
+  };
+
+  class ReferenceScanner : public ObjectScanner {
+   public:
+    ReferenceScanner(v8::Value& search_value) : search_value_(search_value){};
+
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
+                   v8::Error& err) override;
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
+                   v8::Error& err) override;
+
+   private:
+    v8::Value& search_value_;
+  };
 };
 
 class MemoryVisitor {

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1311,6 +1311,86 @@ void JSObject::Keys(std::vector<std::string>& keys, Error& err) {
   return;
 }
 
+
+void JSObject::Entries(std::vector<std::pair<Value, Value>>& entries,
+                       Error& err) {
+  entries.clear();
+
+  HeapObject map_obj = GetMap(err);
+
+  Map map(map_obj);
+
+  bool is_dict = map.IsDictionary(err);
+  if (err.Fail()) return;
+
+  if (is_dict) {
+    DictionaryEntries(entries, err);
+  } else {
+    DescriptorEntries(entries, map, err);
+  }
+
+  return;
+}
+
+void JSObject::DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
+                                 Error& err) {
+  HeapObject dictionary_obj = Properties(err);
+  if (err.Fail()) return;
+
+  NameDictionary dictionary(dictionary_obj);
+
+  int64_t length = dictionary.Length(err);
+  if (err.Fail()) return;
+
+  Value::InspectOptions options;
+
+  for (int64_t i = 0; i < length; i++) {
+    Value key = dictionary.GetKey(i, err);
+
+    if (err.Fail()) return;
+
+    // Skip holes
+    bool is_hole = key.IsHoleOrUndefined(err);
+    if (err.Fail()) return;
+    if (is_hole) continue;
+
+    Value value = dictionary.GetValue(i, err);
+
+
+    entries.push_back(std::pair<Value, Value>(key, value));
+  }
+}
+
+void JSObject::DescriptorEntries(std::vector<std::pair<Value, Value>>& entries,
+                                 Map map, Error& err) {
+  HeapObject descriptors_obj = map.InstanceDescriptors(err);
+  if (err.Fail()) return;
+
+  DescriptorArray descriptors(descriptors_obj);
+  int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
+  if (err.Fail()) return;
+
+  for (int64_t i = 0; i < own_descriptors_count; i++) {
+    Smi details = descriptors.GetDetails(i, err);
+    if (err.Fail()) return;
+
+    Value key = descriptors.GetKey(i, err);
+    if (err.Fail()) return;
+
+    // Skip non-fields for now, Object.keys(obj) does
+    // not seem to return these (for example the "length"
+    // field on an array).
+    if (!descriptors.IsFieldDetails(details)) {
+      continue;
+    }
+
+    Value value = descriptors.GetValue(i, err);
+
+    entries.push_back(std::pair<Value, Value>(key, value));
+  }
+}
+
+
 void JSObject::ElementKeys(std::vector<std::string>& keys, Error& err) {
   HeapObject elements_obj = Elements(err);
   if (err.Fail()) return;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1328,9 +1328,8 @@ void JSObject::Entries(std::vector<std::pair<Value, Value>>& entries,
   } else {
     DescriptorEntries(entries, map, err);
   }
-
-  return;
 }
+
 
 void JSObject::DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
                                  Error& err) {
@@ -1341,8 +1340,6 @@ void JSObject::DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
 
   int64_t length = dictionary.Length(err);
   if (err.Fail()) return;
-
-  Value::InspectOptions options;
 
   for (int64_t i = 0; i < length; i++) {
     Value key = dictionary.GetKey(i, err);
@@ -1356,10 +1353,10 @@ void JSObject::DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
 
     Value value = dictionary.GetValue(i, err);
 
-
     entries.push_back(std::pair<Value, Value>(key, value));
   }
 }
+
 
 void JSObject::DescriptorEntries(std::vector<std::pair<Value, Value>>& entries,
                                  Map map, Error& err) {
@@ -1423,8 +1420,6 @@ void JSObject::DictionaryKeys(std::vector<std::string>& keys, Error& err) {
 
   int64_t length = dictionary.Length(err);
   if (err.Fail()) return;
-
-  Value::InspectOptions options;
 
   for (int64_t i = 0; i < length; i++) {
     Value key = dictionary.GetKey(i, err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -10,6 +10,7 @@
 namespace llnode {
 
 class FindJSObjectsVisitor;
+class FindReferencesCmd;
 
 namespace v8 {
 
@@ -236,6 +237,13 @@ class JSObject : public HeapObject {
   std::string InspectDictionary(Error& err);
   std::string InspectDescriptors(Map map, Error& err);
   void Keys(std::vector<std::string>& keys, Error& err);
+
+  /** Return all the key/value pairs for properties on a JSObject
+   * This allows keys to be inflated to JSStrings later once we know if
+   * they are needed.
+   */
+  void Entries(std::vector<std::pair<Value, Value>>& entries, Error& err);
+
   Value GetProperty(std::string key_name, Error& err);
   int64_t GetArrayLength(Error& err);
   Value GetArrayElement(int64_t pos, Error& err);
@@ -247,6 +255,10 @@ class JSObject : public HeapObject {
   void ElementKeys(std::vector<std::string>& keys, Error& err);
   void DictionaryKeys(std::vector<std::string>& keys, Error& err);
   void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
+  void DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
+                         Error& err);
+  void DescriptorEntries(std::vector<std::pair<Value, Value>>& entries, Map map,
+                         Error& err);
   Value GetDictionaryProperty(std::string key_name, Error& err);
   Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
 };
@@ -492,6 +504,7 @@ class LLV8 {
   friend class JSDate;
   friend class CodeMap;
   friend class llnode::FindJSObjectsVisitor;
+  friend class llnode::FindReferencesCmd;
 };
 
 #undef V8_VALUE_DEFAULT_METHODS

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -242,7 +242,7 @@ class JSObject : public HeapObject {
    * This allows keys to be inflated to JSStrings later once we know if
    * they are needed.
    */
-  void Entries(std::vector<std::pair<Value, Value>>& entries, Error& err);
+  std::vector<std::pair<Value, Value>> Entries(Error& err);
 
   Value GetProperty(std::string key_name, Error& err);
   int64_t GetArrayLength(Error& err);
@@ -255,10 +255,8 @@ class JSObject : public HeapObject {
   void ElementKeys(std::vector<std::string>& keys, Error& err);
   void DictionaryKeys(std::vector<std::string>& keys, Error& err);
   void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
-  void DictionaryEntries(std::vector<std::pair<Value, Value>>& entries,
-                         Error& err);
-  void DescriptorEntries(std::vector<std::pair<Value, Value>>& entries, Map map,
-                         Error& err);
+  std::vector<std::pair<Value, Value>> DictionaryEntries(Error& err);
+  std::vector<std::pair<Value, Value>> DescriptorEntries(Map map, Error& err);
   Value GetDictionaryProperty(std::string key_name, Error& err);
   Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
 };


### PR DESCRIPTION
This PR adds a findrefs command to llnode to allow a user to search for all references to an object.

At the moment it’s just scanning the same set of objects that findjsobjects and findjsinstances use. That might miss references from v8 internals but does limit the results to things a JavaScript programmer has direct control over. That may need to change later on.

I’ve got a blog posting explaining the command ready to go, I’ll update it before posting with any feedback and changes to the command. I’ll also do an update to the v8 usage in README.md afterwards just to reflect the current contents of the help but the number of commands is starting to build up a bit. Would it be worth discussing (under a separate issue) about where in the project is the right place to put some more documentation and what it might need?