### PR TITLE
Add —-print-source (-s) flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/indutny/llnode.png)](http://travis-ci.org/indutny/llnode)
 
-Node.js v4.x-v6.x C++ plugin for LLDB.
+Node.js v4.x-v6.x C++ plugin for [LLDB](http://lldb.llvm.org) - a next generation, high-performance debugger.
 
 ## Demo
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -322,6 +322,9 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
                 "Print information about Node.js\n");
 
+  v8.AddCommand("findrefs", new llnode::FindReferencesCmd(),
+                "Find all the objects that refer to the specified object.\n");
+
   return true;
 }
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -21,6 +21,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       {"full-string", no_argument, nullptr, 'F'},
       {"string-length", required_argument, nullptr, 0x1001},
       {"print-map", no_argument, nullptr, 'm'},
+      {"print-source", no_argument, nullptr, 's'},
       {nullptr, 0, nullptr, 0}};
 
   int argc = 0;
@@ -29,7 +30,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, cmd - 1, "Fm", opts, nullptr);
+    int arg = getopt_long(argc, cmd - 1, "Fms", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
@@ -41,6 +42,9 @@ char** CommandBase::ParseInspectOptions(char** cmd,
         break;
       case 0x1001:
         options->string_length = strtol(optarg, nullptr, 10);
+        break;
+      case 's':
+        options->print_source = true;
         break;
       default:
         continue;
@@ -281,6 +285,7 @@ bool PluginInitialize(SBDebugger d) {
       "Possible flags (all optional):\n\n"
       " * -F, --full-string    - print whole string without adding ellipsis\n"
       " * -m, --print-map      - print object's map address\n"
+      " * -s, --print-source   - print source code for function objects\n"
       " * --string-length num  - print maximum of `num` characters in string\n"
       "\n"
       "Syntax: v8 inspect [flags] expr\n");

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -348,6 +348,7 @@ uint64_t FindJSObjectsVisitor::Visit(uint64_t location, uint64_t available) {
   v8::Value::InspectOptions inspect_options;
   inspect_options.detailed = false;
   inspect_options.print_map = false;
+  inspect_options.print_source = false;
   inspect_options.string_length = 0;
 
   std::string type_name = heap_object.GetTypeName(&inspect_options, err);

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -68,6 +68,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
   return true;
 }
 
+
 bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
                                  SBCommandReturnObject& result) {
   if (*cmd == NULL) {
@@ -78,6 +79,12 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
   SBTarget target = d.GetSelectedTarget();
   if (!target.IsValid()) {
     result.SetError("No valid process, please start something\n");
+    return false;
+  }
+
+  /* Ensure we have a map of objects. */
+  if (!llscan.ScanHeapForObjects(target, result)) {
+    result.SetStatus(eReturnStatusFailed);
     return false;
   }
 
@@ -116,6 +123,7 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
   result.SetStatus(eReturnStatusSuccessFinishResult);
   return true;
 }
+
 
 bool NodeInfoCmd::DoExecute(SBDebugger d, char** cmd,
                             SBCommandReturnObject& result) {
@@ -286,6 +294,183 @@ bool NodeInfoCmd::DoExecute(SBDebugger d, char** cmd,
   }
 
   return true;
+}
+
+
+bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
+                                  SBCommandReturnObject& result) {
+  if (*cmd == NULL) {
+    result.SetError("USAGE: v8 findreferences expr\n");
+    return false;
+  }
+
+  SBTarget target = d.GetSelectedTarget();
+  if (!target.IsValid()) {
+    result.SetError("No valid process, please start something\n");
+    return false;
+  }
+
+  /* Ensure we have a map of objects. */
+  if (!llscan.ScanHeapForObjects(target, result)) {
+    result.SetStatus(eReturnStatusFailed);
+    return false;
+  }
+
+  v8::Value::InspectOptions inspect_options;
+
+  inspect_options.detailed = detailed_;
+
+  char** start = ParseInspectOptions(cmd, &inspect_options);
+
+  // Currently the only parameter is the pointer to search for which
+  // should be a valid lldb expression.
+
+  std::string full_cmd;
+  for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;
+
+  SBExpressionOptions options;
+  SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
+
+  // Load V8 constants from postmortem data
+  llv8.Load(target);
+
+  if (value.GetError().Fail()) {
+    SBStream desc;
+    if (value.GetError().GetDescription(desc)) {
+      result.SetError(desc.GetData());
+    }
+    result.SetStatus(eReturnStatusFailed);
+    return false;
+  }
+
+  // Check the address we've been given at least looks like a valid object.
+  v8::Value search_value(&llv8, value.GetValueAsSigned());
+  v8::Smi smi(search_value);
+  if (smi.Check()) {
+    result.SetError("Search value is an SMI.");
+    return false;
+  }
+
+  /* We can add options to the command and further sub-classes of
+   * object scanner to do other searches, e.g.:
+   * - Objects that refer to a particular string literal.
+   *   (lldb) findreferences -s "Hello World!"
+   * - Objects that contain a property with a particular name
+   *   instead of a value:
+   *   (lldb) findreferences -p "version"
+   */
+  ReferenceScanner scanner(search_value);
+
+  // Walk all the object instances and handle them according to their type.
+  TypeRecordMap mapstoinstances = llscan.GetMapsToInstances();
+  for (auto const entry : mapstoinstances) {
+    TypeRecord* typerecord = entry.second;
+    for (uint64_t addr : typerecord->GetInstances()) {
+      v8::Error err;
+      v8::Value obj_value(&llv8, addr);
+      v8::HeapObject heap_object(obj_value);
+      int64_t type = heap_object.GetType(err);
+      v8::LLV8* v8 = heap_object.v8();
+
+      // We only need to handle the types that are in
+      // FindJSObjectsVisitor::IsAHistogramType
+      // as those are the only objects that end up in GetMapsToInstances
+      if (type == v8->types()->kJSObjectType ||
+          type == v8->types()->kJSArrayType) {
+        // Objects can have elements and arrays can have named properties.
+        // Basically we need to access objects and arrays as both objects and
+        // arrays.
+        v8::JSObject js_obj(heap_object);
+        scanner.PrintRefs(result, js_obj, err);
+
+      } else if (type < v8->types()->kFirstNonstringType) {
+        v8::String str(heap_object);
+        scanner.PrintRefs(result, str, err);
+
+      } else if (type < v8->types()->kJSTypedArrayType) {
+        // These should only point to off heap memory,
+        // this case should be a no-op.
+      } else {
+        // result.Printf("Unhandled type: %" PRId64 " for addr %" PRIx64
+        //    "\n", type, addr);
+      }
+    }
+  }
+
+  result.SetStatus(eReturnStatusSuccessFinishResult);
+  return true;
+}
+
+
+void FindReferencesCmd::ReferenceScanner::PrintRefs(
+    SBCommandReturnObject& result, v8::JSObject& js_obj, v8::Error& err) {
+  v8::Value::InspectOptions inspect_options;
+  inspect_options.detailed = false;
+  int64_t length = js_obj.GetArrayLength(err);
+  for (int64_t i = 0; i < length; ++i) {
+    v8::Value v = js_obj.GetArrayElement(i, err);
+    if (err.Success() && v.raw() == search_value_.raw()) {
+      std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+      result.Printf("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n",
+                    js_obj.raw(), type_name.c_str(), i, search_value_.raw());
+    }
+  }
+
+  // Walk all the properties in this object.
+  // We only create strings for the field names that match the search
+  // value.
+  std::vector<std::pair<v8::Value, v8::Value>> entries = js_obj.Entries(err);
+  if (err.Success()) {
+    for (auto entry : entries) {
+      v8::Value v = entry.second;
+      if (v.raw() == search_value_.raw()) {
+        std::string key = entry.first.ToString(err);
+        std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+        result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", js_obj.raw(),
+                      type_name.c_str(), key.c_str(), search_value_.raw());
+      }
+    }
+  }
+}
+
+
+void FindReferencesCmd::ReferenceScanner::PrintRefs(
+    SBCommandReturnObject& result, v8::String& str, v8::Error& err) {
+  v8::Value::InspectOptions inspect_options;
+  inspect_options.detailed = false;
+  v8::LLV8* v8 = str.v8();
+
+  int64_t repr = str.Representation(err);
+
+  // Concatenated and sliced strings refer to other strings so
+  // we need to check their references.
+
+  if (repr == v8->string()->kSlicedStringTag) {
+    v8::SlicedString sliced_str(str);
+    v8::String parent = sliced_str.Parent(err);
+    if (err.Success() && parent.raw() == search_value_.raw()) {
+      std::string type_name = sliced_str.GetTypeName(&inspect_options, err);
+      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+                    type_name.c_str(), "<Parent>", search_value_.raw());
+    }
+  } else if (repr == v8->string()->kConsStringTag) {
+    v8::ConsString cons_str(str);
+
+    v8::String first = cons_str.First(err);
+    if (err.Success() && first.raw() == search_value_.raw()) {
+      std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+                    type_name.c_str(), "<First>", search_value_.raw());
+    }
+
+    v8::String second = cons_str.Second(err);
+    if (err.Success() && second.raw() == search_value_.raw()) {
+      std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+                    type_name.c_str(), "<Second>", search_value_.raw());
+    }
+  }
+  // Nothing to do for other kinds of string.
 }
 
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -34,6 +34,39 @@ class NodeInfoCmd : public CommandBase {
                  lldb::SBCommandReturnObject& result) override;
 };
 
+class FindReferencesCmd : public CommandBase {
+ public:
+  ~FindReferencesCmd() override{};
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+ private:
+  bool detailed_;
+
+  class ObjectScanner {
+   public:
+    ~ObjectScanner(){};
+    virtual void PrintRefs(lldb::SBCommandReturnObject& result,
+                           v8::JSObject& js_obj, v8::Error& err){};
+    virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
+                           v8::Error& err){};
+  };
+
+  class ReferenceScanner : public ObjectScanner {
+   public:
+    ReferenceScanner(v8::Value& search_value) : search_value_(search_value){};
+
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
+                   v8::Error& err) override;
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
+                   v8::Error& err) override;
+
+   private:
+    v8::Value& search_value_;
+  };
+};
+
 class MemoryVisitor {
  public:
   virtual ~MemoryVisitor(){};

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -235,6 +235,8 @@ void SharedInfo::Load() {
   kCodeOffset = LoadConstant("class_SharedFunctionInfo__code__Code");
   kStartPositionOffset =
       LoadConstant("class_SharedFunctionInfo__start_position_and_type__SMI");
+  kEndPositionOffset =
+      LoadConstant("class_SharedFunctionInfo__end_position__SMI");
   kParameterCountOffset = LoadConstant(
       "class_SharedFunctionInfo__internal_formal_parameter_count__SMI",
       "class_SharedFunctionInfo__formal_parameter_count__SMI");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -167,6 +167,7 @@ class SharedInfo : public Module {
   int64_t kScriptOffset;
   int64_t kCodeOffset;
   int64_t kStartPositionOffset;
+  int64_t kEndPositionOffset;
   int64_t kParameterCountOffset;
   int64_t kScopeInfoOffset;
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -247,6 +247,15 @@ inline int64_t SharedFunctionInfo::StartPosition(Error& err) {
   return field;
 }
 
+// TODO (hhellyer): as above, this field is different on 32bit.
+inline int64_t SharedFunctionInfo::EndPosition(Error& err) {
+  int64_t field = LoadField(v8()->shared_info()->kEndPositionOffset, err);
+  if (err.Fail()) return -1;
+
+  field &= 0xffffffff;
+  return field >> 1;
+}
+
 ACCESSOR(JSFunction, Info, js_function()->kSharedInfoOffset,
          SharedFunctionInfo);
 ACCESSOR(JSFunction, GetContext, js_function()->kContextOffset, HeapObject);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1394,6 +1394,84 @@ void JSObject::Keys(std::vector<std::string>& keys, Error& err) {
   return;
 }
 
+
+std::vector<std::pair<Value, Value>> JSObject::Entries(Error& err) {
+  HeapObject map_obj = GetMap(err);
+
+  Map map(map_obj);
+
+  bool is_dict = map.IsDictionary(err);
+  if (err.Fail()) return {};
+
+  if (is_dict) {
+    return DictionaryEntries(err);
+  } else {
+    return DescriptorEntries(map, err);
+  }
+}
+
+
+std::vector<std::pair<Value, Value>> JSObject::DictionaryEntries(Error& err) {
+  HeapObject dictionary_obj = Properties(err);
+  if (err.Fail()) return {};
+
+  NameDictionary dictionary(dictionary_obj);
+
+  int64_t length = dictionary.Length(err);
+  if (err.Fail()) return {};
+
+  std::vector<std::pair<Value, Value>> entries;
+  for (int64_t i = 0; i < length; i++) {
+    Value key = dictionary.GetKey(i, err);
+
+    if (err.Fail()) return entries;
+
+    // Skip holes
+    bool is_hole = key.IsHoleOrUndefined(err);
+    if (err.Fail()) return entries;
+    if (is_hole) continue;
+
+    Value value = dictionary.GetValue(i, err);
+
+    entries.push_back(std::pair<Value, Value>(key, value));
+  }
+  return entries;
+}
+
+
+std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map, Error& err) {
+  HeapObject descriptors_obj = map.InstanceDescriptors(err);
+  if (err.Fail()) return {};
+
+  DescriptorArray descriptors(descriptors_obj);
+
+  int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
+  if (err.Fail()) return {};
+
+  std::vector<std::pair<Value, Value>> entries;
+  for (int64_t i = 0; i < own_descriptors_count; i++) {
+    Smi details = descriptors.GetDetails(i, err);
+    if (err.Fail()) return entries;
+
+    Value key = descriptors.GetKey(i, err);
+    if (err.Fail()) return entries;
+
+    // Skip non-fields for now, Object.keys(obj) does
+    // not seem to return these (for example the "length"
+    // field on an array).
+    if (!descriptors.IsFieldDetails(details)) {
+      continue;
+    }
+
+    Value value = descriptors.GetValue(i, err);
+
+    entries.push_back(std::pair<Value, Value>(key, value));
+  }
+
+  return entries;
+}
+
+
 void JSObject::ElementKeys(std::vector<std::string>& keys, Error& err) {
   HeapObject elements_obj = Elements(err);
   if (err.Fail()) return;
@@ -1426,8 +1504,6 @@ void JSObject::DictionaryKeys(std::vector<std::string>& keys, Error& err) {
 
   int64_t length = dictionary.Length(err);
   if (err.Fail()) return;
-
-  Value::InspectOptions options;
 
   for (int64_t i = 0; i < length; i++) {
     Value key = dictionary.GetKey(i, err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -10,6 +10,7 @@
 namespace llnode {
 
 class FindJSObjectsVisitor;
+class FindReferencesCmd;
 
 namespace v8 {
 
@@ -241,6 +242,13 @@ class JSObject : public HeapObject {
   std::string InspectDictionary(Error& err);
   std::string InspectDescriptors(Map map, Error& err);
   void Keys(std::vector<std::string>& keys, Error& err);
+
+  /** Return all the key/value pairs for properties on a JSObject
+   * This allows keys to be inflated to JSStrings later once we know if
+   * they are needed.
+   */
+  std::vector<std::pair<Value, Value>> Entries(Error& err);
+
   Value GetProperty(std::string key_name, Error& err);
   int64_t GetArrayLength(Error& err);
   Value GetArrayElement(int64_t pos, Error& err);
@@ -252,6 +260,8 @@ class JSObject : public HeapObject {
   void ElementKeys(std::vector<std::string>& keys, Error& err);
   void DictionaryKeys(std::vector<std::string>& keys, Error& err);
   void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
+  std::vector<std::pair<Value, Value>> DictionaryEntries(Error& err);
+  std::vector<std::pair<Value, Value>> DescriptorEntries(Map map, Error& err);
   Value GetDictionaryProperty(std::string key_name, Error& err);
   Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
 };
@@ -498,6 +508,7 @@ class LLV8 {
   friend class JSDate;
   friend class CodeMap;
   friend class llnode::FindJSObjectsVisitor;
+  friend class llnode::FindReferencesCmd;
 };
 
 #undef V8_VALUE_DEFAULT_METHODS

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -47,12 +47,16 @@ class Value {
   class InspectOptions {
    public:
     InspectOptions()
-        : detailed(false), print_map(false), string_length(kStringLength) {}
+        : detailed(false),
+          print_map(false),
+          print_source(false),
+          string_length(kStringLength) {}
 
     static const unsigned int kStringLength = 16;
 
     bool detailed;
     bool print_map;
+    bool print_source;
     unsigned int string_length;
   };
 
@@ -172,6 +176,7 @@ class SharedFunctionInfo : public HeapObject {
   inline HeapObject GetScopeInfo(Error& err);
   inline int64_t ParameterCount(Error& err);
   inline int64_t StartPosition(Error& err);
+  inline int64_t EndPosition(Error& err);
 
   std::string ProperName(Error& err);
   std::string GetPostfix(Error& err);
@@ -270,6 +275,7 @@ class JSFunction : public JSObject {
 
   std::string GetDebugLine(std::string args, Error& err);
   std::string Inspect(InspectOptions* options, Error& err);
+  std::string GetSource(Error& err);
 };
 
 class JSRegExp : public JSObject {

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -27,6 +27,7 @@ function closure() {
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;
   c.hashmap[23] = /regexp/;
+  c.hashmap[25] = (a,b)=>{a+b};
 
   let scopedVar = 'scoped value';
 

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -47,6 +47,7 @@ tape('v8 inspect', (t) => {
 
   let regexp = null;
   let cons = null;
+  let arrowFunc = null;
 
   sess.wait(/Object/, (line) => {
     t.notEqual(line.indexOf(hashmap), -1, 'addr of `Object` should match');
@@ -61,6 +62,11 @@ tape('v8 inspect', (t) => {
         /\[23\]=(0x[0-9a-f]+):<(?:Object: RegExp|JSRegExp source=\/regexp\/)>/);
     t.ok(reMatch, '[23] RegExp element');
     regexp = reMatch[1];
+
+    const arrowMatch = lines.match(
+    /\[25\]=(0x[0-9a-f]+):<(function: c.hashmap).*>/);
+    t.ok(arrowMatch, '[25] Arrow Function element');
+    arrowFunc = arrowMatch[1];
 
     t.ok(/.some-key=<Smi: 42>/.test(lines), '.some-key property');
     t.ok(/.other-key=[^\n]*<String: "ohai">/.test(lines),
@@ -90,6 +96,22 @@ tape('v8 inspect', (t) => {
         -1,
         'cons string content');
 
+    sess.send(`v8 inspect -s ${arrowFunc}`);
+  });
+
+  sess.linesUntil(/^>/, (lines) => {
+    lines = lines.join('\n');
+    // Include 'source:' and '>' to act as boundaries. (Avoid
+    // passing if the whole file it displayed instead of just
+    // the function we want.)
+    const arrowSource = 'source:\n' +
+        'function c.hashmap.(anonymous function)(a,b)=>{a+b}\n' +
+        '>'
+
+    t.ok(lines.includes(
+        arrowSource),
+        'arrow method source');
+
     sess.send(`v8 inspect -s ${fn}`);
   });
 
@@ -107,7 +129,7 @@ tape('v8 inspect', (t) => {
 
     t.ok(lines.includes(
         methodSource),
-        "method source found");
+        'method source found');
 
     if (process.version < 'v5.0.0') {
       sess.quit();

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -100,9 +100,9 @@ tape('v8 inspect', (t) => {
     // passing if the whole file it displayed instead of just
     // the function we want.)
     const methodSource = "  source:\n" +
-    "  Class.prototype.method = function method() {\n" +
+    "function method() {\n" +
     "    throw new Error('Uncaught');\n" +
-    "  };\n" +
+    "  }\n" +
     ">"
 
     t.ok(lines.includes(


### PR DESCRIPTION
This adds the option to display the full source associated with any function object via a --print-source (-s) flag when running v8 inspect. I think the choice of flag name makes sense but I'm happy to change it.

Some sample output is below. I'm happy to change the format of the output, though I can't do much about the formatting on the code that's being displayed. :-)

Sample output:
(lldb) v8 inspect --print-source 0x000022689a088939
0x000022689a088939:<function: helloworld at callfunctions.js:13:20
  context=0x000022689a0888a9
  source:
function helloworld() {
	console.log("Hello World!");
}
>