### PR TITLE
readme: update Travis CI badge to reflect new github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llnode
 
-[![Build Status](https://secure.travis-ci.org/indutny/llnode.png)](http://travis-ci.org/indutny/llnode)
+[![Build Status](https://travis-ci.org/nodejs/llnode.svg)](http://travis-ci.org/nodejs/llnode)
 
 Node.js v4.x-v6.x C++ plugin for LLDB.
 


### PR DESCRIPTION
For some reason the current badge doesn't work anymore. I'm not a hundred percent sure this is related to the move to the nodejs org, but in any case I guess this should be updated.

I've also modified the URL slightly to reflect the latest conventions. Hopefully that's ok :)

As far as I can see the builds have not been enabled on Travis yet, so this change will not work before someone on the Node.js org does that I guess.
