### PR TITLE
llv8.cc - Guard against obviously invalid string lengths.

### DIFF
--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -84,6 +84,11 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
 
 
 std::string LLV8::LoadString(int64_t addr, int64_t length, Error& err) {
+  if( length < 0 ) {
+    err = Error::Failure("Failed to load V8 one byte string - Invalid length");
+    return std::string();
+  }
+
   char* buf = new char[length + 1];
   SBError sberr;
   process_.ReadMemory(static_cast<addr_t>(addr), buf,
@@ -105,13 +110,18 @@ std::string LLV8::LoadString(int64_t addr, int64_t length, Error& err) {
 
 
 std::string LLV8::LoadTwoByteString(int64_t addr, int64_t length, Error& err) {
+  if( length < 0 ) {
+    err = Error::Failure("Failed to load V8 two byte string - Invalid length");
+    return std::string();
+  }
+
   char* buf = new char[length * 2 + 1];
   SBError sberr;
   process_.ReadMemory(static_cast<addr_t>(addr), buf,
                       static_cast<size_t>(length * 2), sberr);
   if (sberr.Fail()) {
     // TODO(indutny): add more information
-    err = Error::Failure("Failed to load V8 one byte string");
+    err = Error::Failure("Failed to load V8 two byte string");
     delete[] buf;
     return std::string();
   }

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -84,7 +84,7 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
 
 
 std::string LLV8::LoadString(int64_t addr, int64_t length, Error& err) {
-  if( length < 0 ) {
+  if (length < 0) {
     err = Error::Failure("Failed to load V8 one byte string - Invalid length");
     return std::string();
   }
@@ -110,7 +110,7 @@ std::string LLV8::LoadString(int64_t addr, int64_t length, Error& err) {
 
 
 std::string LLV8::LoadTwoByteString(int64_t addr, int64_t length, Error& err) {
-  if( length < 0 ) {
+  if (length < 0) {
     err = Error::Failure("Failed to load V8 two byte string - Invalid length");
     return std::string();
   }


### PR DESCRIPTION
There shouldn't ever be a string with negative length but v8 could have been doing anything when the core dump was created and something catastrophic may have caused the core dump in the first place. Also because we scan all of memory looking for things that might be objects we may hit something that looked a bit like a string but wasn't really.

This fixes an issue I hit while working with a random test dump. That dump was created with --abort_on_uncaught_exception so this may well be frequent enough happen to someone else as well.
