### PR TITLE
Add findrefs -n to search by property name

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -323,7 +323,12 @@ bool PluginInitialize(SBDebugger d) {
                 "Print information about Node.js\n");
 
   v8.AddCommand("findrefs", new llnode::FindReferencesCmd(),
-                "Find all the objects that refer to the specified object.\n");
+                "Finds all the object properties which meet the search criteria.\n"
+                "The default is to list all the object properties that reference the specified value.\n"
+      "Flags:\n\n"
+      " * -v, --value expr     - all properties that refer to the specified JavaScript object (default)\n"
+      " * -n, --name  name     - all properties with the specified name\n"
+      "\n");
 
   return true;
 }

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -322,11 +322,14 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
                 "Print information about Node.js\n");
 
-  v8.AddCommand("findrefs", new llnode::FindReferencesCmd(),
-                "Finds all the object properties which meet the search criteria.\n"
-                "The default is to list all the object properties that reference the specified value.\n"
+  v8.AddCommand(
+      "findrefs", new llnode::FindReferencesCmd(),
+      "Finds all the object properties which meet the search criteria.\n"
+      "The default is to list all the object properties that reference the "
+      "specified value.\n"
       "Flags:\n\n"
-      " * -v, --value expr     - all properties that refer to the specified JavaScript object (default)\n"
+      " * -v, --value expr     - all properties that refer to the specified "
+      "JavaScript object (default)\n"
       " * -n, --name  name     - all properties with the specified name\n"
       "\n");
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -9,7 +9,7 @@ namespace llnode {
 
 class FindObjectsCmd : public CommandBase {
  public:
-  ~FindObjectsCmd() override{};
+  ~FindObjectsCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
@@ -17,7 +17,7 @@ class FindObjectsCmd : public CommandBase {
 
 class FindInstancesCmd : public CommandBase {
  public:
-  ~FindInstancesCmd() override{};
+  ~FindInstancesCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
@@ -28,7 +28,7 @@ class FindInstancesCmd : public CommandBase {
 
 class NodeInfoCmd : public CommandBase {
  public:
-  ~NodeInfoCmd() override{};
+  ~NodeInfoCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
@@ -36,27 +36,27 @@ class NodeInfoCmd : public CommandBase {
 
 class FindReferencesCmd : public CommandBase {
  public:
-  ~FindReferencesCmd() override{};
+  ~FindReferencesCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
 
-  enum ScanType { fieldvalue, propertyname, badoption };
+  enum ScanType { kFieldValue, kPropertyName, kBadOption };
 
-  char** ParseScanOptions(char** cmd, ScanType& type);
+  char** ParseScanOptions(char** cmd, ScanType* type);
 
   class ObjectScanner {
    public:
-    virtual ~ObjectScanner(){};
+    virtual ~ObjectScanner() {}
     virtual void PrintRefs(lldb::SBCommandReturnObject& result,
-                           v8::JSObject& js_obj, v8::Error& err){};
+                           v8::JSObject& js_obj, v8::Error& err) {}
     virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
-                           v8::Error& err){};
+                           v8::Error& err) {}
   };
 
   class ReferenceScanner : public ObjectScanner {
    public:
-    ReferenceScanner(v8::Value& search_value) : search_value_(search_value){};
+    ReferenceScanner(v8::Value& search_value) : search_value_(search_value) {}
 
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
                    v8::Error& err) override;
@@ -70,7 +70,7 @@ class FindReferencesCmd : public CommandBase {
 
   class PropertyScanner : public ObjectScanner {
    public:
-    PropertyScanner(std::string search_value) : search_value_(search_value){};
+    PropertyScanner(std::string search_value) : search_value_(search_value) {}
 
     // We only scan properties on objects not Strings, use default no-op impl
     // of PrintRefs for Strings.
@@ -84,7 +84,7 @@ class FindReferencesCmd : public CommandBase {
 
 class MemoryVisitor {
  public:
-  virtual ~MemoryVisitor(){};
+  virtual ~MemoryVisitor() {}
 
   virtual uint64_t Visit(uint64_t location, uint64_t available) = 0;
 };
@@ -92,7 +92,7 @@ class MemoryVisitor {
 class TypeRecord {
  public:
   TypeRecord(std::string& type_name)
-      : type_name_(type_name), instance_count_(0), total_instance_size_(0){};
+      : type_name_(type_name), instance_count_(0), total_instance_size_(0) {}
 
   inline std::string& GetTypeName() { return type_name_; };
   inline uint64_t GetInstanceCount() { return instance_count_; };
@@ -150,7 +150,7 @@ class FindJSObjectsVisitor : MemoryVisitor {
 
 class LLScan {
  public:
-  LLScan(){};
+  LLScan() {}
 
   bool ScanHeapForObjects(lldb::SBTarget target,
                           lldb::SBCommandReturnObject& result);
@@ -167,7 +167,7 @@ class LLScan {
   class MemoryRange {
    public:
     MemoryRange(uint64_t start, uint64_t length)
-        : start_(start), length_(length), next_(nullptr){};
+        : start_(start), length_(length), next_(nullptr) {}
 
     uint64_t start_;
     uint64_t length_;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1482,7 +1482,6 @@ std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map,
     Value key = descriptors.GetKey(i, err);
     if (err.Fail()) continue;
 
-
     if (descriptors.IsConstFieldDetails(details)) {
       Value value;
 
@@ -1493,32 +1492,23 @@ std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map,
       continue;
     }
 
-
     // Skip non-fields for now, Object.keys(obj) does
     // not seem to return these (for example the "length"
     // field on an array).
     if (!descriptors.IsFieldDetails(details)) continue;
 
+    if (descriptors.IsDoubleField(details)) continue;
+
     int64_t index = descriptors.FieldIndex(details) - in_object_count;
 
-    if (descriptors.IsDoubleField(details)) {
-      double value;
-      if (index < 0) {
-        value = GetInObjectValue<double>(instance_size, index, err);
-      } else {
-        value = extra_properties.Get<double>(index, err);
-      }
-      // entries.push_back(std::pair<Value, Value>(key, value));
+    Value value;
+    if (index < 0) {
+      value = GetInObjectValue<Value>(instance_size, index, err);
     } else {
-      Value value;
-      if (index < 0) {
-        value = GetInObjectValue<Value>(instance_size, index, err);
-      } else {
-        value = extra_properties.Get<Value>(index, err);
-      }
-
-      entries.push_back(std::pair<Value, Value>(key, value));
+      value = extra_properties.Get<Value>(index, err);
     }
+
+    entries.push_back(std::pair<Value, Value>(key, value));
   }
 
   return entries;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1453,7 +1453,8 @@ std::vector<std::pair<Value, Value>> JSObject::DictionaryEntries(Error& err) {
 }
 
 
-std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map, Error& err) {
+std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map,
+                                                                 Error& err) {
   HeapObject descriptors_obj = map.InstanceDescriptors(err);
   if (err.Fail()) return {};
 
@@ -1462,24 +1463,62 @@ std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map, Error&
   int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
   if (err.Fail()) return {};
 
+  int64_t in_object_count = map.InObjectProperties(err);
+  if (err.Fail()) return {};
+
+  int64_t instance_size = map.InstanceSize(err);
+  if (err.Fail()) return {};
+
+  HeapObject extra_properties_obj = Properties(err);
+  if (err.Fail()) return {};
+
+  FixedArray extra_properties(extra_properties_obj);
+
   std::vector<std::pair<Value, Value>> entries;
   for (int64_t i = 0; i < own_descriptors_count; i++) {
     Smi details = descriptors.GetDetails(i, err);
-    if (err.Fail()) return entries;
+    if (err.Fail()) continue;
 
     Value key = descriptors.GetKey(i, err);
-    if (err.Fail()) return entries;
+    if (err.Fail()) continue;
+
+
+    if (descriptors.IsConstFieldDetails(details)) {
+      Value value;
+
+      value = descriptors.GetValue(i, err);
+      if (err.Fail()) continue;
+
+      entries.push_back(std::pair<Value, Value>(key, value));
+      continue;
+    }
+
 
     // Skip non-fields for now, Object.keys(obj) does
     // not seem to return these (for example the "length"
     // field on an array).
-    if (!descriptors.IsFieldDetails(details)) {
-      continue;
+    if (!descriptors.IsFieldDetails(details)) continue;
+
+    int64_t index = descriptors.FieldIndex(details) - in_object_count;
+
+    if (descriptors.IsDoubleField(details)) {
+      double value;
+      if (index < 0) {
+        value = GetInObjectValue<double>(instance_size, index, err);
+      } else {
+        value = extra_properties.Get<double>(index, err);
+      }
+      // entries.push_back(std::pair<Value, Value>(key, value));
+    } else {
+      Value value;
+      if (index < 0) {
+        value = GetInObjectValue<Value>(instance_size, index, err);
+      } else {
+        value = extra_properties.Get<Value>(index, err);
+      }
+
+      entries.push_back(std::pair<Value, Value>(key, value));
     }
-
-    Value value = descriptors.GetValue(i, err);
-
-    entries.push_back(std::pair<Value, Value>(key, value));
   }
 
   return entries;


### PR DESCRIPTION
This change adds a -n <name> option to v8 findrefs to search for all references referred to from properties named <name>. It also adds a -v option that matches the current (and still default with no flag specified) behaviour where all references to a property with that value are returned.

When findrefs was added ( https://github.com/nodejs/llnode/pull/32 ) I refactored it’s code as part of the review so that it could be easily extended. This enhancement takes advantage of that.

The output is the same as findrefs <object address> so the user sees the referring object address, it’s type, the field name and the object referred to from that property. Effectively it is scanning for all objects that contain a property with a particular name but the output is quite concise and allows the user to immediately inspect the object they are interested 

e.g:
(lldb) v8 findrefs --name constructor
0x2b57415b1211: (Array).constructor=0x2b57415b0f99
0x2f0367543b79: FastBuffer.constructor=0x2f036753dfa9
0x2f03675e2a51: KnownObject.constructor=0x2f03675e29f1
0x1d8468cdde11: Object.constructor=0x2b57415af6c1
0x1d8468cdde81: Object.constructor=0x2b57415cfc21
…

Searching for properties by name produces even more output than by value. I will look at adding the output limit we also discussed in https://github.com/nodejs/llnode/pull/32 next.
