### PR TITLE
llnode.cc: Fix linux options parsing crash.

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -33,7 +33,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   // for getopt_long to use in its error messages.
   char name[] = "llnode";
   args[0] = name;
-  for (int i = 0; i < argc; i++) args[i+1] = cmd[i];
+  for (int i = 0; i < argc - 1; i++) args[i + 1] = cmd[i];
 
   // Reset getopts.
   optind = 1;
@@ -61,7 +61,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   } while (true);
 
   // Use the original cmd array for our return value.
-  return cmd + (optind - 1);
+  return &cmd[optind - 1];
 }
 
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -24,13 +24,22 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       {"print-source", no_argument, nullptr, 's'},
       {nullptr, 0, nullptr, 0}};
 
-  int argc = 0;
+  int argc = 1;
   for (char** p = cmd; p != nullptr && *p != nullptr; p++) argc++;
 
-  optind = 0;
+  char* args[argc];
+
+  // Make this look like a command line, we need a valid element at index 0
+  // for getopt_long to use in its error messages.
+  char name[] = "llnode";
+  args[0] = name;
+  for (int i = 0; i < argc; i++) args[i+1] = cmd[i];
+
+  // Reset getopts.
+  optind = 1;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, cmd - 1, "Fms", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fms", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
@@ -51,7 +60,8 @@ char** CommandBase::ParseInspectOptions(char** cmd,
     }
   } while (true);
 
-  return cmd + optind - 1;
+  // Use the original cmd array for our return value.
+  return cmd + (optind - 1);
 }
 
 


### PR DESCRIPTION
Fix up the arguments array to contain a first element rather than
subtract 1 from the lldb arguments and pretend they start at
args[1].
Linux prints args[0] in it's error message so it must point to a real
array element.
(Mac OSX appears to be hardcoded to use the program name in argv[0]
and ignores the first element of the arguments array.)

Fixes #41 