### PR TITLE
Add findrefs -s flag to search by property

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -341,6 +341,8 @@ bool PluginInitialize(SBDebugger d) {
       " * -v, --value expr     - all properties that refer to the specified "
       "JavaScript object (default)\n"
       " * -n, --name  name     - all properties with the specified name\n"
+      " * -s, --string string  - all properties that refer to the specified "
+      "JavaScript string value\n"
       "\n");
 
   return true;

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -41,7 +41,7 @@ class FindReferencesCmd : public CommandBase {
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
 
-  enum ScanType { kFieldValue, kPropertyName, kBadOption };
+  enum ScanType { kFieldValue, kPropertyName, kStringValue, kBadOption };
 
   char** ParseScanOptions(char** cmd, ScanType* type);
 
@@ -75,6 +75,20 @@ class FindReferencesCmd : public CommandBase {
     // We only scan properties on objects not Strings, use default no-op impl
     // of PrintRefs for Strings.
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
+                   v8::Error& err) override;
+
+   private:
+    std::string search_value_;
+  };
+
+
+  class StringScanner : public ObjectScanner {
+   public:
+    StringScanner(std::string search_value) : search_value_(search_value) {}
+
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
+                   v8::Error& err) override;
+    void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                    v8::Error& err) override;
 
    private:


### PR DESCRIPTION
This PR adds the ability to search for a property where the value is a given javascript string. It functions much the same as the search for a value by id (address) but will match any JavaScript string that is equal to the string passed on the command line. This means it can potentially match more than one JavaScript object.

Luckily the lldb command line interpreter takes care of handling quoted strings. All I’ve added is a check for extra parameters when someone should have quoted a string.