### PR TITLE
llv8-constants: Use file address for symbol lookup

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -57,7 +57,7 @@ static int64_t LookupConstant(SBTarget target, const char* name, int64_t def,
   SBError sberr;
 
   SBProcess process = target.GetProcess();
-  addr_t addr = start.GetLoadAddress(target);
+  addr_t addr = start.GetFileAddress();
 
   // NOTE: size could be bigger for at the end symbols
   if (size >= 8) {


### PR DESCRIPTION
I hit an issue using llnode with the latest master branch of lldb. It couldn't read any of the values for the constants from Linux core dumps.
It turns out that up to lldb 3.9 GetLoadAddress and GetFileAddress return the same value. In the current master branch of lldb they seem to return different values on Linux and GetFileAddress returns the one we should read to obtain the symbol value. (On Mac they always seem to return the same value.)

The only discussion I can find on the differences between a file address and load address are in an lldb review request for updating the documentation: https://reviews.llvm.org/D22831
based on that I think we should be using file address if we want to read that memory address later.

I've checked the fix on the default Mac lldb, lldb 3.9 on Linux and Mac and lldb from master with Linux and Mac core files and live processes.