### PR TITLE
llscan: GetTypeName remove unused parameter

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -496,8 +496,6 @@ char** FindReferencesCmd::ParseScanOptions(char** cmd, ScanType* type) {
 
 void FindReferencesCmd::ReferenceScanner::PrintRefs(
     SBCommandReturnObject& result, v8::JSObject& js_obj, v8::Error& err) {
-  v8::Value::InspectOptions inspect_options;
-  inspect_options.detailed = false;
   int64_t length = js_obj.GetArrayLength(err);
   for (int64_t i = 0; i < length; ++i) {
     v8::Value v = js_obj.GetArrayElement(i, err);
@@ -507,7 +505,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
 
     if (v.raw() != search_value_.raw()) continue;
 
-    std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+    std::string type_name = js_obj.GetTypeName(err);
     result.Printf("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n",
                   js_obj.raw(), type_name.c_str(), i, search_value_.raw());
   }
@@ -523,7 +521,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::Value v = entry.second;
     if (v.raw() == search_value_.raw()) {
       std::string key = entry.first.ToString(err);
-      std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+      std::string type_name = js_obj.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", js_obj.raw(),
                     type_name.c_str(), key.c_str(), search_value_.raw());
     }
@@ -533,8 +531,6 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
 
 void FindReferencesCmd::ReferenceScanner::PrintRefs(
     SBCommandReturnObject& result, v8::String& str, v8::Error& err) {
-  v8::Value::InspectOptions inspect_options;
-  inspect_options.detailed = false;
   v8::LLV8* v8 = str.v8();
 
   int64_t repr = str.Representation(err);
@@ -546,7 +542,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::SlicedString sliced_str(str);
     v8::String parent = sliced_str.Parent(err);
     if (err.Success() && parent.raw() == search_value_.raw()) {
-      std::string type_name = sliced_str.GetTypeName(&inspect_options, err);
+      std::string type_name = sliced_str.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
                     type_name.c_str(), "<Parent>", search_value_.raw());
     }
@@ -555,14 +551,14 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
 
     v8::String first = cons_str.First(err);
     if (err.Success() && first.raw() == search_value_.raw()) {
-      std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+      std::string type_name = cons_str.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
                     type_name.c_str(), "<First>", search_value_.raw());
     }
 
     v8::String second = cons_str.Second(err);
     if (err.Success() && second.raw() == search_value_.raw()) {
-      std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+      std::string type_name = cons_str.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
                     type_name.c_str(), "<Second>", search_value_.raw());
     }
@@ -573,8 +569,6 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
 
 void FindReferencesCmd::PropertyScanner::PrintRefs(
     SBCommandReturnObject& result, v8::JSObject& js_obj, v8::Error& err) {
-  v8::Value::InspectOptions inspect_options;
-  inspect_options.detailed = false;
 
   // (Note: We skip array elements as they don't have names.)
 
@@ -592,7 +586,7 @@ void FindReferencesCmd::PropertyScanner::PrintRefs(
       continue;
     }
     if (key == search_value_) {
-      std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+      std::string type_name = js_obj.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", js_obj.raw(),
                     type_name.c_str(), key.c_str(), entry.second.raw());
     }
@@ -603,8 +597,6 @@ void FindReferencesCmd::PropertyScanner::PrintRefs(
 void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
                                                  v8::JSObject& js_obj,
                                                  v8::Error& err) {
-  v8::Value::InspectOptions inspect_options;
-  inspect_options.detailed = false;
   v8::LLV8* v8 = js_obj.v8();
 
   int64_t length = js_obj.GetArrayLength(err);
@@ -626,7 +618,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
         continue;
       }
       if (err.Success() && search_value_ == value) {
-        std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+        std::string type_name = js_obj.GetTypeName(err);
 
         result.Printf("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 " '%s'\n",
                       js_obj.raw(), type_name.c_str(), i, v.raw(),
@@ -657,7 +649,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
           if (err.Fail()) {
             continue;
           }
-          std::string type_name = js_obj.GetTypeName(&inspect_options, err);
+          std::string type_name = js_obj.GetTypeName(err);
           result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n",
                         js_obj.raw(), type_name.c_str(), key.c_str(),
                         entry.second.raw(), value.c_str());
@@ -671,8 +663,6 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
 void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
                                                  v8::String& str,
                                                  v8::Error& err) {
-  v8::Value::InspectOptions inspect_options;
-  inspect_options.detailed = false;
   v8::LLV8* v8 = str.v8();
 
   // Concatenated and sliced strings refer to other strings so
@@ -687,7 +677,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
     if (err.Fail()) return;
     std::string parent = parent_str.ToString(err);
     if (err.Success() && search_value_ == parent) {
-      std::string type_name = sliced_str.GetTypeName(&inspect_options, err);
+      std::string type_name = sliced_str.GetTypeName(err);
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n", str.raw(),
                     type_name.c_str(), "<Parent>", parent_str.raw(),
                     parent.c_str());
@@ -708,7 +698,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
       std::string first = first_str.ToString(err);
 
       if (err.Success() && search_value_ == first) {
-        std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+        std::string type_name = cons_str.GetTypeName(err);
         result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n", str.raw(),
                       type_name.c_str(), "<First>", first_str.raw(),
                       first.c_str());
@@ -728,7 +718,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
       std::string second = second_str.ToString(err);
 
       if (err.Success() && search_value_ == second) {
-        std::string type_name = cons_str.GetTypeName(&inspect_options, err);
+        std::string type_name = cons_str.GetTypeName(err);
         result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n", str.raw(),
                       type_name.c_str(), "<Second>", second_str.raw(),
                       second.c_str());
@@ -770,18 +760,13 @@ uint64_t FindJSObjectsVisitor::Visit(uint64_t location, uint64_t word) {
 
   MapCacheEntry map_info;
   if (map_cache_.count(map.raw()) == 0) {
-    v8::Value::InspectOptions inspect_options;
-    inspect_options.detailed = false;
-    inspect_options.print_map = false;
-    inspect_options.print_source = false;
-    inspect_options.string_length = 0;
 
     // Check type first
     map_info.is_histogram = IsAHistogramType(map, err);
 
     // On success load type name
     if (map_info.is_histogram)
-      map_info.type_name = heap_object.GetTypeName(&inspect_options, err);
+      map_info.type_name = heap_object.GetTypeName(err);
 
     // Cache result
     map_cache_.emplace(map.raw(), map_info);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -652,7 +652,7 @@ std::string Value::Inspect(InspectOptions* options, Error& err) {
 }
 
 
-std::string Value::GetTypeName(InspectOptions* options, Error& err) {
+std::string Value::GetTypeName(Error& err) {
   Smi smi(this);
   if (smi.Check()) return "(Smi)";
 
@@ -662,7 +662,7 @@ std::string Value::GetTypeName(InspectOptions* options, Error& err) {
     return std::string();
   }
 
-  return obj.GetTypeName(options, err);
+  return obj.GetTypeName(err);
 }
 
 
@@ -791,7 +791,7 @@ std::string Smi::ToString(Error& err) {
 
 /* Utility function to generate short type names for objects.
  */
-std::string HeapObject::GetTypeName(InspectOptions* options, Error& err) {
+std::string HeapObject::GetTypeName(Error& err) {
   int64_t type = GetType(err);
   if (type == v8()->types()->kGlobalObjectType) return "(Global)";
   if (type == v8()->types()->kCodeType) return "(Code)";

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -75,7 +75,7 @@ class Value {
   bool IsHole(Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);
-  std::string GetTypeName(InspectOptions* options, Error& err);
+  std::string GetTypeName(Error& err);
   std::string ToString(Error& err);
 
  protected:
@@ -110,7 +110,7 @@ class HeapObject : public Value {
 
   std::string ToString(Error& err);
   std::string Inspect(InspectOptions* options, Error& err);
-  std::string GetTypeName(InspectOptions* options, Error& err);
+  std::string GetTypeName(Error& err);
 };
 
 class Map : public HeapObject {


### PR DESCRIPTION
Remove the unused parameter "InspectOptions* options" from GetTypeName

This fixes issue #48