### PR TITLE
llnode: properly reset `getopt` on linuxes

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -36,7 +36,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   for (int i = 0; i < argc - 1; i++) args[i + 1] = cmd[i];
 
   // Reset getopts.
-  optind = 1;
+  optind = 0;
   opterr = 1;
   do {
     int arg = getopt_long(argc, args, "Fms", opts, nullptr);

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -459,7 +459,7 @@ char** FindReferencesCmd::ParseScanOptions(char** cmd, ScanType* type) {
   bool found_scan_type = false;
 
   // Reset getopts.
-  optind = 1;
+  optind = 0;
   opterr = 1;
   do {
     int arg = getopt_long(argc, args, "vns", opts, nullptr);
@@ -489,7 +489,7 @@ char** FindReferencesCmd::ParseScanOptions(char** cmd, ScanType* type) {
     }
   } while (true);
 
-  return cmd + optind - 1;
+  return &cmd[optind - 1];
 }
 
 


### PR DESCRIPTION
When `getopt` is called it starts seeking from the last char it has
seen. Unfortunately, that last char may be part of the string that was
already deallocated.

Set `optind` to `0` to reset the state properly on Linux.

See: https://github.com/nodejs/llnode/pull/35#issuecomment-262854793

cc @hhellyer @yjhjstz 