### PR TITLE
make: test different lldb versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+LLDB_VERSION ?= 3.6
+
 all:
 	@echo "Please take a look at README.md"
 
@@ -19,9 +21,9 @@ uninstall-linux:
 format:
 	clang-format -i src/*
 
-_travis:
-	./gyp_llnode -Dlldb_dir=/usr/lib/llvm-3.6/ -f make
+ci:
+	./gyp_llnode -Dlldb_dir=/usr/lib/llvm-$(LLDB_VERSION)/ -f make
 	make -C out/
-	TEST_LLDB_BINARY=`which lldb-3.6` npm test
+	TEST_LLDB_BINARY=`which lldb-$(LLDB_VERSION)` npm test
 
-.PHONY: all
+.PHONY: all install-osx uninstall-osx install-linux uninstall-linux format ci


### PR DESCRIPTION
cc @hhellyer @yjhjstz

@rvagg , we would like to test several different lldb versions to assure compatibility:

* `3.6` (as we do now)
* `3.7`
* `3.8`
* `3.9`

All seem to be available on Xenial. Also, I'd like to change makefile target to `ci`, so it will be `make ci`. 

Could you please help us?