### PR TITLE
llnode.cc: Only mention ranges file if it is needed.

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -319,7 +319,7 @@ bool PluginInitialize(SBDebugger d) {
                 "debugged.\n"
                 "There are scripts for generating this file on Linux and Mac "
                 "in the scripts directory of the llnode repository."
-#endif // LLDB_SBMemoryRegionInfoList_h_
+#endif  // LLDB_SBMemoryRegionInfoList_h_
                 );
 
   interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -313,11 +313,14 @@ bool PluginInitialize(SBDebugger d) {
   v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
                 "List all object types and instance counts grouped by map and "
                 "sorted by instance count.\n"
+#ifndef LLDB_SBMemoryRegionInfoList_h_
                 "Requires `LLNODE_RANGESFILE` environment variable to be set "
                 "to a file containing memory ranges for the core file being "
                 "debugged.\n"
                 "There are scripts for generating this file on Linux and Mac "
-                "in the scripts directory of the llnode repository.");
+                "in the scripts directory of the llnode repository."
+#endif // LLDB_SBMemoryRegionInfoList_h_
+                );
 
   interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
                          "Alias for `v8 findjsobjects`");


### PR DESCRIPTION
Since we are starting to see people using lldb 3.9 in the field (at least on Linux) this just makes sure they don't see confusing help messages that don't apply since 3.9 has the SBMemoryRegionInfoList API available.