### PR TITLE
Fix bug in v8 findrefs command, reference search fails

### DIFF
--- a/src/llscan.h
+++ b/src/llscan.h
@@ -56,7 +56,7 @@ class FindReferencesCmd : public CommandBase {
 
   class ReferenceScanner : public ObjectScanner {
    public:
-    ReferenceScanner(v8::Value& search_value) : search_value_(search_value) {}
+    ReferenceScanner(v8::Value search_value) : search_value_(search_value) {}
 
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::JSObject& js_obj,
                    v8::Error& err) override;
@@ -64,7 +64,7 @@ class FindReferencesCmd : public CommandBase {
                    v8::Error& err) override;
 
    private:
-    v8::Value& search_value_;
+    v8::Value search_value_;
   };
 
 


### PR DESCRIPTION
Line 353 in llscan.c creates a `ReferenceScanner`, passing in a `v8::Value `for the search parameter. The parameter on the `ReferenceScanner `constructor is defined and hence passed as a C++ reference, but the scope of the `v8::Value` passed in is block local, see line 346 in llscan.c. So the search value is a wild reference when used later.

Fix is to change the definition of the `ReferenceScanner` constructor to pass the parameter by value.