### PR TITLE
Fix and docs for lldb system plugin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ uninstall-osx:
 	rm ~/Library/Application\ Support/LLDB/PlugIns/llnode.dylib
 
 install-linux:
-	mkdir -p /usr/lib/lldb
-	cp -rf ./out/Release/lib.target/llnode.so /usr/lib/lldb/
+	mkdir -p /usr/lib/lldb/plugins
+	cp -rf ./out/Release/lib.target/llnode.so /usr/lib/lldb/plugins
 
 uninstall-linux:
-	rm /usr/lib/lldb/llnode.so
+	rm /usr/lib/lldb/plugins/llnode.so
 
 format:
 	clang-format -i src/*

--- a/README.md
+++ b/README.md
@@ -75,10 +75,38 @@ make -C out/ -j9
 sudo make install-linux
 ```
 
-### Usage
+## Usage
+
+The plugin call be loaded in LLDB using the `plugin load` command, or
+installed in the LLDB system plugin directory. LLDB will then load the
+plugin automatically on start-up. 
+
+### OS X
 
 ```
 lldb
+
+(lldb) plugin load ./node-modules/llnode/llnode.dylib
+```
+
+To install the plugin in the LLDB system plugin directory, use the
+`make install-osx` build step above, or if installing
+with npm copy `node_modules/llnode/llnode.dylib` to
+` ~/Library/Application\ Support/LLDB/PlugIns/`.
+
+### Linux
+
+```
+lldb
+
+(lldb) plugin load ./node-modules/llnode/llnode.so
+```
+To install the plugin in the LLDB system plugin directory, use the
+`make install-linux` build step above, or if installing with
+npm by copying `node_modules/llnode/llnode.so` to
+`/usr/lib/lldb/plugins`.
+
+```
 (lldb) v8 help
      Node.js helpers
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ sudo make install-linux
 
 ## Usage
 
-The plugin call be loaded in LLDB using the `plugin load` command, or
-installed in the LLDB system plugin directory. LLDB will then load the
-plugin automatically on start-up. 
+The llnode plugin can be loaded into LLDB using the `plugin load` command.
+Alternatively it can be installed in the LLDB system plugin directory, in
+which case LLDB will load the plugin automatically on start-up. 
 
 ### OS X
 
@@ -103,7 +103,7 @@ lldb
 ```
 To install the plugin in the LLDB system plugin directory, use the
 `make install-linux` build step above, or if installing with
-npm by copying `node_modules/llnode/llnode.so` to
+npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
 
 ```

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -18,4 +18,5 @@ console.log(`Copying ${cwd}/out/Release/${llnodeLib} to ${cwd}/${llnodeLib}`);
 child_process.execSync(`mv ${cwd}/out/Release/${llnodeLib} ${cwd}/${llnodeLib}`);
 
 console.log(`${os.EOL}llnode plugin installed, load in lldb with:`);
-console.log(`(lldb) plugin load ${cwd}/${llnodeLib}${os.EOL}`);
+console.log(`(lldb) plugin load ${cwd}/${llnodeLib}`);
+console.log(`or copy plugin to lldb system plugin directory${os.EOL}`);

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -19,4 +19,4 @@ child_process.execSync(`mv ${cwd}/out/Release/${llnodeLib} ${cwd}/${llnodeLib}`)
 
 console.log(`${os.EOL}llnode plugin installed, load in lldb with:`);
 console.log(`(lldb) plugin load ${cwd}/${llnodeLib}`);
-console.log(`or copy plugin to lldb system plugin directory${os.EOL}`);
+console.log(`or copy plugin to lldb system plugin directory, see www.npmjs.org/llnode${os.EOL}`);


### PR DESCRIPTION
Fix makefile to install llnode as system plugin for linux in /usr/lib/lldb/plugins not /usr/lib/lldb. Also add README docs for usage of lldb system plugin directory vs `plugin load`.

Fixes #71 

We could have the npm install also do the copy to the system plugin directory, but on Linux that would need root/sudo. Maybe it could be an extra option on the npm install. Anyway, I think it's worth having this documented in the README as it's not obvious what's going on.

