### PR TITLE
Fix issue with gcc 7 confusing gyp_llnode

### DIFF
--- a/gyp_llnode
+++ b/gyp_llnode
@@ -37,6 +37,8 @@ def compiler_version():
   is_clang = 'clang' in proc.communicate()[0].split('\n')[0]
   proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
   version = proc.communicate()[0].split('.')
+  # Allow for (e.g.) gcc version 7 (not 7.0)
+  version.append("0")
   version = map(int, version[:2])
   version = tuple(version)
   return (version, is_clang)

--- a/gyp_llnode
+++ b/gyp_llnode
@@ -38,7 +38,7 @@ def compiler_version():
   proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
   version = proc.communicate()[0].split('.')
   # Allow for (e.g.) gcc version 7 (not 7.0)
-  version.append("0")
+  version.append('0')
   version = map(int, version[:2])
   version = tuple(version)
   return (version, is_clang)


### PR DESCRIPTION
cc -dumpversion only reports 7 (not 7.0) on gcc 7, this confuses
the code that expects a two digit version.
This patch just makes sure the version number is padded to at least
two digits so 7 will report 7.0.