### PR TITLE
configure.js: Update lldb header downloads.

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const child_process = require('child_process');
 
 const lldbReleases = {
-  '4.0': 'master',
+  '4.0': 'release_40',
   '3.9': 'release_39',
   '3.8': 'release_38',
   '3.7': 'release_37',
@@ -116,7 +116,9 @@ function getDarwinRelease() {
   // console.log('Xcode version is ' + version_str)
 
   var version = parseFloat(versionStr);
-  if (version > 8.0) {
+  if (version >= 8.3) {
+    return '3.9';
+  } else if (version > 8.0) {
     return '3.8';
   } else {
     return '3.4';


### PR DESCRIPTION
The default version of lldb on MacOS now contains the
SBMemoryRegionInfo API allowing us to scan the heap without
using the scripts to generate a segments file.

This simplifies the use of llnode as the v8 find* commands
are now automatically available to the user.