### PR TITLE
src,test: support node.js >= 8

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1029,4 +1029,4 @@ void LLScan::ClearMapsToInstances() {
   }
   GetMapsToInstances().clear();
 }
-}
+}  // namespace llnode

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -200,7 +200,7 @@ class LLScan {
   TypeRecordMap mapstoinstances_;
 };
 
-}  // llnode
+}  // namespace llnode
 
 
 #endif  // SRC_LLSCAN_H_

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -423,6 +423,36 @@ void DescriptorArray::Load() {
   kPropertyIndexShift = LoadConstant("prop_index_shift");
   kPropertyTypeMask = LoadConstant("prop_type_mask");
 
+  if (kPropertyTypeMask == -1) {  // node.js >= 8
+    kPropertyAttributesMask = LoadConstant("prop_attributes_mask");
+    kPropertyAttributesShift = LoadConstant("prop_attributes_shift");
+    kPropertyAttributesEnum_NONE = LoadConstant("prop_attributes_NONE");
+    kPropertyAttributesEnum_READ_ONLY =
+        LoadConstant("prop_attributes_READ_ONLY");
+    kPropertyAttributesEnum_DONT_ENUM =
+        LoadConstant("prop_attributes_DONT_ENUM");
+    kPropertyAttributesEnum_DONT_DELETE =
+        LoadConstant("prop_attributes_DONT_ENUM");
+
+    kPropertyKindMask = LoadConstant("prop_kind_mask");
+    kPropertyKindShift = LoadConstant("prop_kind_shift", int64_t(0));
+    kPropertyKindEnum_kAccessor = LoadConstant("prop_kind_Accessor");
+    kPropertyKindEnum_kData = LoadConstant("prop_kind_Data");
+
+    kPropertyLocationMask = LoadConstant("prop_location_mask");
+    kPropertyLocationShift = LoadConstant("prop_location_shift");
+    kPropertyLocationEnum_kDescriptor =
+        LoadConstant("prop_location_Descriptor");
+    kPropertyLocationEnum_kField = LoadConstant("prop_location_Field");
+  } else {  // node.js <= 7
+    kFieldType = LoadConstant("prop_type_field");
+    kConstFieldType = LoadConstant("prop_type_const_field");
+    if (kConstFieldType == -1) {
+      // TODO(indutny): check V8 version?
+      kConstFieldType = kFieldType | 0x2;
+    }
+  }
+
   kRepresentationShift = LoadConstant("prop_representation_shift");
   kRepresentationMask = LoadConstant("prop_representation_mask");
 
@@ -430,13 +460,6 @@ void DescriptorArray::Load() {
     // TODO(indutny): check V8 version?
     kRepresentationShift = 5;
     kRepresentationMask = ((1 << 4) - 1) << kRepresentationShift;
-  }
-
-  kFieldType = LoadConstant("prop_type_field");
-  kConstFieldType = LoadConstant("prop_type_const_field");
-  if (kConstFieldType == -1) {
-    // TODO(indutny): check V8 version?
-    kConstFieldType = kFieldType | 0x2;
   }
 
   kRepresentationDouble = LoadConstant("prop_representation_double");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -374,16 +374,36 @@ class DescriptorArray : public Module {
 
   int64_t kPropertyIndexMask;
   int64_t kPropertyIndexShift;
-  int64_t kPropertyTypeMask;
   int64_t kRepresentationMask;
   int64_t kRepresentationShift;
 
-  int64_t kFieldType;
-  int64_t kConstFieldType;
   int64_t kRepresentationDouble;
 
   int64_t kFirstIndex;
   int64_t kSize;
+
+  // node.js <= 7
+  int64_t kPropertyTypeMask = -1;
+  int64_t kConstFieldType = -1;
+  int64_t kFieldType = -1;
+
+  // node.js >= 8
+  int64_t kPropertyAttributesMask = -1;
+  int64_t kPropertyAttributesShift = -1;
+  int64_t kPropertyAttributesEnum_NONE = -1;
+  int64_t kPropertyAttributesEnum_READ_ONLY = -1;
+  int64_t kPropertyAttributesEnum_DONT_ENUM = -1;
+  int64_t kPropertyAttributesEnum_DONT_DELETE = -1;
+
+  int64_t kPropertyKindMask = -1;
+  int64_t kPropertyKindShift = -1;
+  int64_t kPropertyKindEnum_kAccessor = -1;
+  int64_t kPropertyKindEnum_kData = -1;
+
+  int64_t kPropertyLocationMask = -1;
+  int64_t kPropertyLocationShift = -1;
+  int64_t kPropertyLocationEnum_kDescriptor = -1;
+  int64_t kPropertyLocationEnum_kField = -1;
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -352,13 +352,31 @@ inline Value DescriptorArray::GetValue(int index, Error& err) {
 }
 
 inline bool DescriptorArray::IsFieldDetails(Smi details) {
-  return (details.GetValue() & v8()->descriptor_array()->kPropertyTypeMask) ==
-         v8()->descriptor_array()->kFieldType;
+  // node.js <= 7
+  if (v8()->descriptor_array()->kPropertyTypeMask != -1) {
+    return (details.GetValue() & v8()->descriptor_array()->kPropertyTypeMask) ==
+           v8()->descriptor_array()->kFieldType;
+  }
+
+  // node.js >= 8
+  return (details.GetValue() &
+          v8()->descriptor_array()->kPropertyLocationMask) ==
+         (v8()->descriptor_array()->kPropertyLocationEnum_kField
+          << v8()->descriptor_array()->kPropertyLocationShift);
 }
 
 inline bool DescriptorArray::IsConstFieldDetails(Smi details) {
-  return (details.GetValue() & v8()->descriptor_array()->kPropertyTypeMask) ==
-         v8()->descriptor_array()->kConstFieldType;
+  // node.js <= 7
+  if (v8()->descriptor_array()->kPropertyTypeMask != -1) {
+    return (details.GetValue() & v8()->descriptor_array()->kPropertyTypeMask) ==
+           v8()->descriptor_array()->kConstFieldType;
+  }
+
+  // node.js >= 8
+  return (details.GetValue() &
+          v8()->descriptor_array()->kPropertyAttributesMask) ==
+         (v8()->descriptor_array()->kPropertyAttributesEnum_READ_ONLY
+          << v8()->descriptor_array()->kPropertyAttributesShift);
 }
 
 inline bool DescriptorArray::IsDoubleField(Smi details) {

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -68,7 +68,14 @@ tape('v8 findrefs and friends', (t) => {
   });
 
   sess.linesUntil(/lldb\-/, (lines) => {
-    t.ok(/Deflate\._handle/.test(lines.join('\n')), 'Should find reference');
+    // `class Deflate extends Zlib` makes instances show up as
+    // Transform objects (which Zlib inherits from) in node.js >= 8.
+    // Note that the version check will have to be redone for node.js >= 10
+    // but that is still a year out and by then llnode probably needs more
+    // fixups anyway.
+    const re =
+        (process.version >= 'v8.' ? /Transform\._handle/ : /Deflate\._handle/);
+    t.ok(re.test(lines.join('\n')), 'Should find reference');
     t.ok(/Object\.holder/.test(lines.join('\n')), 'Should find reference #2');
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');
 


### PR DESCRIPTION
This depends on changes that haven't been upstreamed yet.  Diff for the eager:
```diff
diff --git a/deps/v8/tools/gen-postmortem-metadata.py b/deps/v8/tools/gen-postmortem-metadata.py
index 8857134..8f8d8a1 100644
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -99,6 +99,22 @@ consts_misc = [
         'value': 'kAccessor' },
     { 'name': 'prop_kind_mask',
         'value': 'PropertyDetails::KindField::kMask' },
+    { 'name': 'prop_location_Descriptor',
+        'value': 'kDescriptor' },
+    { 'name': 'prop_location_Field',
+        'value': 'kField' },
+    { 'name': 'prop_location_mask',
+        'value': 'PropertyDetails::LocationField::kMask' },
+    { 'name': 'prop_location_shift',
+        'value': 'PropertyDetails::LocationField::kShift' },
+    { 'name': 'prop_attributes_NONE', 'value': 'NONE' },
+    { 'name': 'prop_attributes_READ_ONLY', 'value': 'READ_ONLY' },
+    { 'name': 'prop_attributes_DONT_ENUM', 'value': 'DONT_ENUM' },
+    { 'name': 'prop_attributes_DONT_DELETE', 'value': 'DONT_DELETE' },
+    { 'name': 'prop_attributes_mask',
+        'value': 'PropertyDetails::AttributesField::kMask' },
+    { 'name': 'prop_attributes_shift',
+        'value': 'PropertyDetails::AttributesField::kShift' },
     { 'name': 'prop_index_mask',
         'value': 'PropertyDetails::FieldIndexField::kMask' },
     { 'name': 'prop_index_shift',
```
Verified locally to work with node.js v4, v6, v7 and v8.0.0-pre and is clang-format clean.