### PR TITLE
src: support V8 5.8 stack frame markers

### DIFF
--- a/src/llv8.h
+++ b/src/llv8.h
@@ -428,6 +428,9 @@ class JSFrame : public Value {
                                uint32_t& lines_found, Error& err);
   std::string Inspect(bool with_args, Error& err);
   std::string InspectArgs(JSFunction fn, Error& err);
+
+ private:
+  Smi FromFrameMarker(Value value) const;
 };
 
 class LLV8 {


### PR DESCRIPTION
On 64 bits systems, V8 stores SMIs (small ints) in the top 32 bits
of a 64 bits word.  Frame markers used to obey this convention but
as of V8 5.8, they are stored as 32 bits SMIs with the top half set
to zero.  Shift the raw value up to make it a normal SMI again.

Fixes test/frame-test.js with the latest node.js v8.0.0-pre, it was
no longer able to detect special JS stack frames like entry and exit
frames, argument adapter frames, etc.