### PR TITLE
README.md: Improve core dump loading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo make install-linux
 
 The llnode plugin can be loaded into LLDB using the `plugin load` command.
 Alternatively it can be installed in the LLDB system plugin directory, in
-which case LLDB will load the plugin automatically on start-up. 
+which case LLDB will load the plugin automatically on start-up.
 
 ### OS X
 
@@ -105,6 +105,21 @@ To install the plugin in the LLDB system plugin directory, use the
 `make install-linux` build step above, or if installing with
 npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
+
+To use llnode with a core dump the core dump needs to be loaded into lldb along with the exact executable that created the core dump. The executable contains information that lldb and llnode need to make sense of the data in the core dump.
+
+To load the core dump when starting lldb use:
+```
+> lldb ~/work/node-sdks/node-v6.5.0-linux-x64/bin/node -c ~/work/core
+```
+or to load the core dump after starting lldb:
+```
+(lldb) target create ~/work/node-sdks/node-v6.5.0-linux-x64/bin/node -c ~/work/core
+```
+
+It does not matter whether the `plugin load` command is issued before or after loading a core dump.
+
+### Commands
 
 ```
 (lldb) v8 help

--- a/README.md
+++ b/README.md
@@ -106,18 +106,22 @@ To install the plugin in the LLDB system plugin directory, use the
 npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
 
-To use llnode with a core dump the core dump needs to be loaded into lldb along with the exact executable that created the core dump. The executable contains information that lldb and llnode need to make sense of the data in the core dump.
+To use llnode with a core dump the core dump needs to be loaded into lldb
+along with the exact executable that created the core dump. The executable
+contains information that lldb and llnode need to make sense of the data in
+the core dump.
 
 To load the core dump when starting lldb use:
 ```
-> lldb ~/work/node-sdks/node-v6.5.0-linux-x64/bin/node -c ~/work/core
+lldb /path/to/bin/node -c /path/to/core
 ```
 or to load the core dump after starting lldb:
 ```
-(lldb) target create ~/work/node-sdks/node-v6.5.0-linux-x64/bin/node -c ~/work/core
+(lldb) target create /path/to/bin/node -c /path/to/core
 ```
 
-It does not matter whether the `plugin load` command is issued before or after loading a core dump.
+It does not matter whether the `plugin load` command is issued before or after
+loading a core dump.
 
 ### Commands
 


### PR DESCRIPTION
Make it clearer how a core dump should be loaded so llnode can obtain all the debug information it needs. I've added the docs to the linux section as (I think) the MacOS core dump actually the executable binaries.

This is for issue #74