### PR TITLE
Fix for installing llnode as a global

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -81,13 +81,20 @@ if (lldbHeadersBranch != undefined) {
 console.log(`Linking lldb to include directory ${lldbIncludeDir}`);
 fs.symlinkSync(lldbIncludeDir, 'lldb');
 
+// npm explore has a different root folder when using -g 
+// So we are tacking on the extra the additional subfolders
+var gypSubDir = 'node-gyp';
+if(process.env.npm_config_global) {
+    gypSubDir = 'npm/node_modules/node-gyp';
+}
+
 // Initialize GYP
 // We can use the node-gyp that comes with npm.
 // We can locate it with npm -g explore npm npm explore node-gyp pwd
 // It might have been neater to make node-gyp one of our dependencies
 // *but* they don't get installed until after the install step has run.
 var gypDir = child_process.execFileSync('npm',
-  ['-g', 'explore', 'npm', 'npm', 'explore', 'node-gyp', 'pwd'],
+  ['-g', 'explore', 'npm', 'npm', 'explore', gypSubDir, 'pwd'],
   {cwd: buildDir}).toString().trim();
 fs.mkdirSync('tools');
 console.log(`Linking tools/gyp to ${gypDir}/gyp`);

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -84,8 +84,8 @@ fs.symlinkSync(lldbIncludeDir, 'lldb');
 // npm explore has a different root folder when using -g 
 // So we are tacking on the extra the additional subfolders
 var gypSubDir = 'node-gyp';
-if(process.env.npm_config_global) {
-    gypSubDir = 'npm/node_modules/node-gyp';
+if (process.env.npm_config_global) {
+  gypSubDir = 'npm/node_modules/node-gyp';
 }
 
 // Initialize GYP


### PR DESCRIPTION
When `npm explore` is ran with a `-g` option the default folder is set to `npm.globalDir` 
which is the root `$GLOBAL/lib/node_modules` folder containing npm. 
But when it's ran in local mode it uses path.resolve(npm.prefix, 'node_modules') 
See https://github.com/npm/npm/blob/latest/lib/npm.js#L395 
This is causing the resolution of node-gyp to fail in global mode. 

This patch tests the npm environment variable `npm_config_global` to see if it's a global install and appends the required sub directories to get it to work.

Tested on Ubuntu 16.04 with 
```
$ git clone https://github.com/no9/llnode
$ cd llnode
$ npm install -g 
```

Fixes: https://github.com/nodejs/llnode/issues/77