### PR TITLE
Freebsd Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ To install the plugin in the LLDB system plugin directory, use the
 npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
 
-```
 
 ### FreeBSD
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ make -C out/ -j9
 sudo make install-linux
 ```
 
+### FreeBSD
+
+```bash
+# Clone this repo
+git clone https://github.com/nodejs/llnode.git && cd llnode
+
+# Install llvm with lldb and headers 
+pkg install llvm39
+rm -f /usr/bin/lldb
+ln -s /usr/local/bin/lldb39 /usr/bin/lldb
+
+# Initialize GYP
+git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
+
+# Configure
+./gyp_llnode -Dlldb_dir=/usr/local/llvm39/
+
+# Build
+gmake -C out/ -j9
+
+# Install
+ComputeSystemPluginsDirectory is not implemented in FreeBSD
+The llnode.so will have to be loaded manually 
+```
+
 ## Usage
 
 The llnode plugin can be loaded into LLDB using the `plugin load` command.
@@ -107,6 +132,13 @@ npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
 
 ```
+
+### FreeBSD
+
+```
+lldb -O plugin load ./node_modules/llnode/llnode.so
+```
+
 (lldb) v8 help
      Node.js helpers
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "//": "(Blame C++)",
   "scripts": {
     "preinstall": "node scripts/configure.js",
-    "install": "./gyp_llnode && if [ `uname` == 'FreeBSD' ]; then gmake -C out/; else make -C out/; fi",
+    "install": "./gyp_llnode && gmake -C out/ || make -C out/",
     "postinstall": "node scripts/cleanup.js",
     "test": "tape test/*-test.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "//": "(Blame C++)",
   "scripts": {
     "preinstall": "node scripts/configure.js",
-    "install": "./gyp_llnode && make -C out/",
+    "install": "./gyp_llnode && if [ `uname` == 'FreeBSD' ]; then gmake -C out/; else make -C out/; fi",
     "postinstall": "node scripts/cleanup.js",
     "test": "tape test/*-test.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "//": "(Blame C++)",
   "scripts": {
     "preinstall": "node scripts/configure.js",
-    "install": "./gyp_llnode && gmake -C out/ || make -C out/",
+    "install": "./gyp_llnode && ( gmake -C out/ || make -C out/ )",
     "postinstall": "node scripts/cleanup.js",
     "test": "tape test/*-test.js"
   },

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -76,7 +76,8 @@ if (osName === 'Darwin') {
     // As this is a BSD we know this system is in an improper state
     // So we can exit with an error
     console.log('The system isn\'t set up correcly.'); 
-    console.log('Try `pkg install llvm39` and `ln -s /usr/local/bin/lldb39 /usr/bin/lldb`');
+    console.log('Try `pkg install llvm39');
+    console.log('And `ln -s /usr/local/bin/lldb39 /usr/bin/lldb`');
     process.exit(1);	  
   } else {
     lldbIncludeDir = installedHeadersDir;

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -62,6 +62,7 @@ if (osName === 'Darwin') {
     lldbIncludeDir = installedHeadersDir;
   }
 } else if (osName === 'FreeBSD') {
+  
   lldbExe = getLldbExecutable();	
   lldbVersion = getFreeBSDVersion(lldbExe);
 
@@ -69,6 +70,7 @@ if (osName === 'Darwin') {
     console.log('Unable to locate lldb binary. llnode installation failed.');
     process.exit(1);  
   }
+  
   var installedHeadersDir = getFreeBSDHeadersDir(lldbVersion);
   if (installedHeadersDir === undefined) {
     // As this is a BSD we know this system is in an improper state
@@ -216,15 +218,13 @@ function getFreeBSDHeadersDir(version) {
   try {
     var includeDir = child_process.execFileSync('llvm-config' + version,
       ['--prefix']).toString().trim();
-    // console.log('Checking for directory ' + include_dir);
-    // Include directory doesn't need include/lldb on the end but the llvm
-    // headers can be installed without the lldb headers so check for them.
     if (fs.existsSync(includeDir + '/include/lldb')) {
-      // console.log('Found ' + include_dir);
       return includeDir;
     }
   } catch (err) {
-    // Return undefined, we will download the headers.
+    console.log(includeDir + '/include/lldb doesn\'nt exist Please see install instructions');	   
+    console.log(err);	  
+    process.exit(1);
   }
   return undefined;
 }

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -52,7 +52,7 @@ if (osName === 'Darwin') {
   }
 
   // console.log('lldb_version is ' + lldb_version)
-  var installedHeadersDir = getLinuxHeadersDir(lldbVersion);
+  const installedHeadersDir = getLinuxHeadersDir(lldbVersion);
   // console.log('installed_headers_dir is ' + installed_headers_dir);
   if (installedHeadersDir === undefined) {
     // Initialising lldb_headers_branch will cause us to clone them.
@@ -62,23 +62,23 @@ if (osName === 'Darwin') {
     lldbIncludeDir = installedHeadersDir;
   }
 } else if (osName === 'FreeBSD') {
-  
-  lldbExe = getLldbExecutable();	
+
+  lldbExe = getLldbExecutable();
   lldbVersion = getFreeBSDVersion(lldbExe);
 
   if (lldbVersion === undefined) {
     console.log('Unable to locate lldb binary. llnode installation failed.');
-    process.exit(1);  
+    process.exit(1);
   }
-  
-  var installedHeadersDir = getFreeBSDHeadersDir(lldbVersion);
+
+  const installedHeadersDir = getFreeBSDHeadersDir(lldbVersion);
   if (installedHeadersDir === undefined) {
     // As this is a BSD we know this system is in an improper state
     // So we can exit with an error
-    console.log('The system isn\'t set up correcly.'); 
+    console.log('The system isn\'t set up correcly.');
     console.log('Try `pkg install llvm39');
     console.log('And `ln -s /usr/local/bin/lldb39 /usr/bin/lldb`');
-    process.exit(1);	  
+    process.exit(1);
   } else {
     lldbIncludeDir = installedHeadersDir;
   }
@@ -213,9 +213,9 @@ function getFreeBSDVersion(lldbExe) {
 }
 
 function getFreeBSDHeadersDir(version) {
-  
+
   console.log('Checking for headers, version is ' + version);
-  
+
   try {
     var includeDir = child_process.execFileSync('llvm-config' + version,
       ['--prefix']).toString().trim();
@@ -223,8 +223,8 @@ function getFreeBSDHeadersDir(version) {
       return includeDir;
     }
   } catch (err) {
-    console.log(includeDir + '/include/lldb doesn\'nt exist Please see install instructions');	   
-    console.log(err);	  
+    console.log(includeDir + '/include/lldb doesn\'nt exist Please see install instructions');
+    console.log(err);
     process.exit(1);
   }
   return undefined;

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -232,7 +232,8 @@ function getFreeBSDHeadersDir(version) {
       return includeDir;
     }
   } catch (err) {
-    console.log(includeDir + '/include/lldb doesn\'nt exist Please see install instructions');
+    console.log(includeDir + '/include/lldb doesn\'nt exist');
+    console.log('Please see README.md');
     console.log(err);
     process.exit(1);
   }

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -2,6 +2,7 @@
 
 const os = require('os');
 const fs = require('fs');
+const path = require('path');
 const child_process = require('child_process');
 
 const lldbReleases = {
@@ -116,13 +117,18 @@ if (process.env.npm_config_global) {
   gypSubDir = 'npm/node_modules/node-gyp';
 }
 
+// npm can be in a different location than the current                                                                                         
+// location for global installs so we need find out where the npm is                                                                              
+var npmLocation = child_process.execFileSync('which', ['npm']);                                                                                           
+var npmModules = path.join(npmLocation.toString(), '../../lib/node_modules/npm'); 
+
 // Initialize GYP
 // We can use the node-gyp that comes with npm.
 // We can locate it with npm -g explore npm npm explore node-gyp pwd
 // It might have been neater to make node-gyp one of our dependencies
 // *but* they don't get installed until after the install step has run.
 var gypDir = child_process.execFileSync('npm',
-  ['-g', 'explore', 'npm', 'npm', 'explore', gypSubDir, 'pwd'],
+  ['-g', 'explore', npmModules, 'npm', 'explore', gypSubDir, 'pwd'],
   {cwd: buildDir}).toString().trim();
 child_process.execSync('rm -rf tools');
 fs.mkdirSync('tools');


### PR DESCRIPTION
This is a patch to enable llnode to work on freebsd from an npm install. 
I think most of the code and docs are pretty straight forward.
It imitates the linux approach currently in place. 
I have intentionally not modified the linux path through the code to make it easy to reason about. 

I am not to sure about the package.json line as it looks verbose 
https://github.com/nodejs/llnode/compare/master...No9:freebsd-install?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R12 
Maybe this should go in its own script now? 