### PR TITLE
src: print builtins and unnamed stack frames

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -11,7 +11,19 @@
 
 namespace llnode {
 
-using namespace lldb;
+using lldb::SBCommandInterpreter;
+using lldb::SBCommandReturnObject;
+using lldb::SBDebugger;
+using lldb::SBError;
+using lldb::SBExpressionOptions;
+using lldb::SBFrame;
+using lldb::SBStream;
+using lldb::SBSymbol;
+using lldb::SBTarget;
+using lldb::SBThread;
+using lldb::SBValue;
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
 
 v8::LLV8 llv8;
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -17,7 +17,6 @@ using lldb::SBDebugger;
 using lldb::SBError;
 using lldb::SBExpressionOptions;
 using lldb::SBFrame;
-using lldb::SBMemoryRegionInfo;
 using lldb::SBStream;
 using lldb::SBSymbol;
 using lldb::SBTarget;
@@ -128,7 +127,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
     // Heuristic: a PC in WX memory is almost certainly a V8 builtin.
     // TODO(bnoordhuis) Find a way to map the PC to the builtin's name.
     {
-      SBMemoryRegionInfo info;
+      lldb::SBMemoryRegionInfo info;
       if (target.GetProcess().GetMemoryRegionInfo(pc, info).Success() &&
           info.IsExecutable() && info.IsWritable()) {
         result.Printf("  %c frame #%u: 0x%016llx <builtin>\n", star, i, pc);

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -17,12 +17,22 @@
 
 namespace llnode {
 
+using lldb::SBCommandReturnObject;
+using lldb::SBDebugger;
+using lldb::SBError;
+using lldb::SBExpressionOptions;
+using lldb::SBMemoryRegionInfo;
+using lldb::SBMemoryRegionInfoList;
+using lldb::SBStream;
+using lldb::SBTarget;
+using lldb::SBValue;
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
+
 // Defined in llnode.cc
 extern v8::LLV8 llv8;
 
 LLScan llscan;
-
-using namespace lldb;
 
 
 bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -12,7 +12,14 @@ namespace llnode {
 namespace v8 {
 namespace constants {
 
-using namespace lldb;
+using lldb::SBAddress;
+using lldb::SBError;
+using lldb::SBProcess;
+using lldb::SBSymbol;
+using lldb::SBSymbolContext;
+using lldb::SBSymbolContextList;
+using lldb::SBTarget;
+using lldb::addr_t;
 
 static std::string kConstantPrefix = "v8dbg_";
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -8,7 +8,9 @@
 namespace llnode {
 namespace v8 {
 
-using namespace lldb;
+using lldb::SBError;
+using lldb::SBTarget;
+using lldb::addr_t;
 
 static std::string kConstantPrefix = "v8dbg_";
 

--- a/test/frame-test.js
+++ b/test/frame-test.js
@@ -15,6 +15,10 @@ tape('v8 stack', (t) => {
   sess.linesUntil(/eyecatcher/, (lines) => {
     lines.reverse();
     t.ok(lines.length > 4, 'frame count');
+    // FIXME(bnoordhuis) This can fail with versions of lldb that don't
+    // support the GetMemoryRegions() API; llnode won't be able to identify
+    // V8 builtins stack frames, it just prints them as anonymous frames.
+    lines = lines.filter((s) => !/<builtin>/.test(s));
     const eyecatcher = lines[0];
     const adapter = lines[1];
     const crasher = lines[2];

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -69,12 +69,12 @@ tape('v8 findrefs and friends', (t) => {
 
   sess.linesUntil(/lldb\-/, (lines) => {
     // `class Deflate extends Zlib` makes instances show up as
-    // Transform objects (which Zlib inherits from) in node.js >= 8.
-    // Note that the version check will have to be redone for node.js >= 10
-    // but that is still a year out and by then llnode probably needs more
-    // fixups anyway.
+    // Transform objects (which Zlib inherits from) in node.js 8.0.0.
+    // That change was reverted in https://github.com/nodejs/node/pull/13374
+    // and released in 8.1.0.
     const re =
-        (process.version >= 'v8.' ? /Transform\._handle/ : /Deflate\._handle/);
+        (process.version === 'v8.0.0' ?
+            /Transform\._handle/ : /Deflate\._handle/);
     t.ok(re.test(lines.join('\n')), 'Should find reference');
     t.ok(/Object\.holder/.test(lines.join('\n')), 'Should find reference #2');
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');


### PR DESCRIPTION
Previously, `v8 bt` would exclude frames that didn't map to a C++ symbol
or a JS stack frame.  llnode does not currently know how to identify the
stack frames of V8 builtins so those were omitted as well.

This commit makes those stack frames visible and introduces a heuristic
(in lldb >= 3.9) where frames whose PC is inside a WX memory segment are
assumed to belong to V8 builtins.

Fixes: #99

First commit is cleanup, second commit fixes a test, third one is the fix for #99.