### PR TITLE
src: don't crash with no arguments to print

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -130,7 +130,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
                          SBCommandReturnObject& result) {
-  if (*cmd == nullptr) {
+  if (cmd == nullptr || *cmd == nullptr) {
     if (detailed_) {
       result.SetError("USAGE: v8 inspect [flags] expr\n");
     } else {
@@ -184,6 +184,11 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool ListCmd::DoExecute(SBDebugger d, char** cmd,
                         SBCommandReturnObject& result) {
+  if (cmd == nullptr || *cmd == nullptr) {
+    result.SetError("USAGE: v8 source list\n");
+    return false;
+  }
+
   static SBFrame last_frame;
   static uint64_t last_line = 0;
   SBTarget target = d.GetSelectedTarget();

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -130,7 +130,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
                          SBCommandReturnObject& result) {
-  if (*cmd == NULL) {
+  if (*cmd == nullptr) {
     if (detailed_) {
       result.SetError("USAGE: v8 inspect [flags] expr\n");
     } else {

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -72,7 +72,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
                                  SBCommandReturnObject& result) {
-  if (*cmd == nullptr) {
+  if (cmd == nullptr || *cmd == nullptr) {
     result.SetError("USAGE: v8 findjsinstances [-Fm] instance_name\n");
     return false;
   }
@@ -300,7 +300,7 @@ bool NodeInfoCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
                                   SBCommandReturnObject& result) {
-  if (*cmd == nullptr) {
+  if (cmd == nullptr || *cmd == nullptr) {
     result.SetError("USAGE: v8 findrefs expr\n");
     return false;
   }

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -72,7 +72,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
                                  SBCommandReturnObject& result) {
-  if (*cmd == NULL) {
+  if (*cmd == nullptr) {
     result.SetError("USAGE: v8 findjsinstances [-Fm] instance_name\n");
     return false;
   }
@@ -300,7 +300,7 @@ bool NodeInfoCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
                                   SBCommandReturnObject& result) {
-  if (*cmd == NULL) {
+  if (*cmd == nullptr) {
     result.SetError("USAGE: v8 findrefs expr\n");
     return false;
   }

--- a/test/usage-test.js
+++ b/test/usage-test.js
@@ -1,0 +1,44 @@
+'use strict';
+const tape = require('tape');
+const common = require('./common');
+
+function removeBlankLines(lines) {
+  return lines.filter((line) => { return line.trim() !== ''; });
+}
+
+tape('usage messages', (t) => {
+  t.timeoutAfter(15000);
+
+  const sess = common.Session.create('inspect-scenario.js');
+
+  sess.waitBreak(() => {
+    sess.send('v8 print');
+  });
+
+  sess.stderr.linesUntil(/USAGE/, (lines) => {
+    t.ok(/^error: USAGE: v8 print expr$/.test(removeBlankLines(lines)[0]),
+         'print usage message');
+    sess.send('v8 source list');
+  });
+
+  sess.stderr.linesUntil(/USAGE/, (lines) => {
+    t.ok(/^error: USAGE: v8 source list$/.test(removeBlankLines(lines)[0]),
+         'list usage message');
+    sess.send('v8 findjsinstances');
+  });
+
+  sess.stderr.linesUntil(/USAGE/, (lines) => {
+    const re = /^error: USAGE: v8 findjsinstances \[-Fm\] instance_name$/;
+
+    t.ok(re.test(removeBlankLines(lines)[0]),
+         'findjsinstances usage message');
+    sess.send('v8 findrefs');
+  });
+
+  sess.stderr.linesUntil(/USAGE/, (lines) => {
+    t.ok(/^error: USAGE: v8 findrefs expr$/.test(removeBlankLines(lines)[0]),
+         'findrefs usage message');
+    sess.quit();
+    t.end();
+  });
+});


### PR DESCRIPTION
This commit prevents a segfault on `v8 print`.

I'll be adding a test as well, but it requires some changes to `test/common.js` first.