### PR TITLE
Add an llnode command script that invokes lldb with the plugin loaded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "directories": {
     "test": "test"
   },
+  "bin" : { "llnode" : "scripts/llnode.sh"},
   "//": "(Blame C++)",
   "scripts": {
     "preinstall": "node scripts/configure.js",

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -225,13 +225,12 @@ function scriptText(lldbExe) {
     lib = 'llnode.dylib';
   }
 
-  return `
-#!/bin/sh
+  return `#!/bin/sh
 
 LLNODE_SCRIPT=\`node -p "path.resolve('$0')"\`
 
 SCRIPT_PATH=\`dirname $LLNODE_SCRIPT\`
-if [ \`basename $SCRIPT_PATH\` == ".bin" ]; then
+if [ \`basename $SCRIPT_PATH\` = ".bin" ]; then
   # llnode installed locally in node_modules/.bin
   LLNODE_PLUGIN="$SCRIPT_PATH/../llnode/${lib}"
 else

--- a/scripts/llnode.sh
+++ b/scripts/llnode.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Place holder script for llnode"
+
+exit 1;


### PR DESCRIPTION
Since @No9 fixed global installation it's more practical to add an llnode command using a `bin` entry in package.json. This is a work in progress PR to get some feedback on whether anyone else thinks it's a good idea.

This implementation is fairly simple, it just wrappers lldb and pre-loads the plugin. (It also changes the prompt so you know it's worked.) Any other argument is just passed straight through so all the existing lldb options can be passed.

This allows the debug workflows:
`$ npm install -g llnode`
followed by:
`$ llnode node -c core` for postmortem debugging.
or
`$ llnode -- node --abort_on_uncaught_exception test.js` for JavaScript debug.
or
`$ llnode -- node test_for_crashing_native_npm.js` for crashes when developing npm modules containing native code.
(There are probably quite a few other use cases. Suggestions are welcome so they can be documented.)

Hopefully this will improve the ease of use and make it easier to recommend llnode to a wider range of Node.js developers. I know the brew installer achieves a similar thing but it's not available for Linux and just installing an npm package feels more "Node-y" which might make a wider audience more likely to use llnode.

Missing from this PR is a re-write of the documentation but I wanted to get some feedback from everyone else before I sat down to do that.