### PR TITLE
src, test: support reading contents from buffers

### DIFF
--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -99,8 +99,10 @@ std::string LLV8::LoadBytes(int64_t length, int64_t addr, Error& err) {
   }
 
   std::string res;
+  char tmp[10];
   for (int i = 0; i < length; ++i) {
-    res += (i == 0 ? " " : ", ") + std::to_string(buf[i]);
+    snprintf(tmp, sizeof(tmp), "%s%02x", (i == 0 ? "" : ", "), buf[i]);
+    res += tmp;
   }
   delete[] buf;
   return res;
@@ -1107,10 +1109,15 @@ std::string JSArrayBuffer::Inspect(InspectOptions* options, Error& err) {
 
   int byte_length = static_cast<int>(length.GetValue());
 
-  std::string res;
   char tmp[128];
+  snprintf(tmp, sizeof(tmp),
+           "<ArrayBuffer: backingStore=0x%016" PRIx64 ", byteLength=%d",
+           data, byte_length);
+  
+  std::string res;
+  res += tmp;
   if (options->detailed) {
-    res += "<ArrayBuffer: [";
+    res += ": [\n  ";
 
     int display_length = std::min<int>(byte_length, options->array_length);
     res += v8()->LoadBytes(display_length, data, err);
@@ -1118,12 +1125,9 @@ std::string JSArrayBuffer::Inspect(InspectOptions* options, Error& err) {
     if (display_length < byte_length) {
       res += " ...";
     }
-    res += " ]>";
+    res += "\n]>";
   } else {
-    snprintf(tmp, sizeof(tmp),
-             "<ArrayBuffer: backingStore=0x%016" PRIx64 ", byteLength=%d>",
-             data, byte_length);
-    res += tmp;
+    res += ">";
   }
 
   return res;
@@ -1150,24 +1154,25 @@ std::string JSArrayBufferView::Inspect(InspectOptions* options, Error& err) {
 
   int byte_length = static_cast<int>(length.GetValue());
   int byte_offset = static_cast<int>(off.GetValue());
-  std::string res;
   char tmp[128];
+  snprintf(tmp, sizeof(tmp),
+           "<ArrayBufferView: backingStore=0x%016" PRIx64 ", byteOffset=%d, byteLength=%d",
+           data, byte_offset, byte_length);
 
+  std::string res;
+  res += tmp;
   if (options->detailed) {
-    res += "<ArrayBufferView: [";
+    res += ": [\n  ";
 
     int display_length = std::min<int>(byte_length, options->array_length);
-
     res += v8()->LoadBytes(display_length, data + byte_offset, err);
+
     if (display_length < byte_length) {
       res += " ...";
     }
-    res += " ]>";
+    res += "\n]>";
   } else {
-    snprintf(tmp, sizeof(tmp),
-             "<ArrayBufferView: backingStore=0x%016" PRIx64 ", byteOffset=%d, byteLength=%d>",
-             data, byte_offset, byte_length);
-    res += tmp;
+    res += ">";
   }
   return res;
 }

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <algorithm>
 
 #include "llv8-inl.h"
 #include "llv8.h"
@@ -85,6 +86,25 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
   return *reinterpret_cast<double*>(&value);
 }
 
+
+std::string LLV8::LoadBytes(int64_t length, int64_t addr, Error& err) {
+  uint8_t* buf = new uint8_t[length + 1];
+  SBError sberr;
+  process_.ReadMemory(addr, buf,
+                      static_cast<size_t>(length), sberr);
+  if (sberr.Fail()) {
+    err = Error::Failure("Failed to load V8 raw buffer");
+    delete[] buf;
+    return std::string();
+  }
+
+  std::string res;
+  for (int i = 0; i < length; ++i) {
+    res += (i == 0 ? " " : ", ") + std::to_string(buf[i]);
+  }
+  delete[] buf;
+  return res;
+}
 
 std::string LLV8::LoadString(int64_t addr, int64_t length, Error& err) {
   if (length < 0) {
@@ -775,12 +795,12 @@ std::string HeapObject::Inspect(InspectOptions* options, Error& err) {
 
   if (type == v8()->types()->kJSArrayBufferType) {
     JSArrayBuffer buf(this);
-    return pre + buf.Inspect(err);
+    return pre + buf.Inspect(options, err);
   }
 
   if (type == v8()->types()->kJSTypedArrayType) {
     JSArrayBufferView view(this);
-    return pre + view.Inspect(err);
+    return pre + view.Inspect(options, err);
   }
 
   if (type == v8()->types()->kJSDateType) {
@@ -1073,8 +1093,7 @@ std::string Oddball::Inspect(Error& err) {
   return "<Oddball>";
 }
 
-
-std::string JSArrayBuffer::Inspect(Error& err) {
+std::string JSArrayBuffer::Inspect(InspectOptions* options, Error& err) {
   bool neutered = WasNeutered(err);
   if (err.Fail()) return std::string();
 
@@ -1086,14 +1105,32 @@ std::string JSArrayBuffer::Inspect(Error& err) {
   Smi length = ByteLength(err);
   if (err.Fail()) return std::string();
 
+  int byte_length = static_cast<int>(length.GetValue());
+
+  std::string res;
   char tmp[128];
-  snprintf(tmp, sizeof(tmp), "<ArrayBuffer 0x%016" PRIx64 ":%d>", data,
-           static_cast<int>(length.GetValue()));
-  return tmp;
+  if (options->detailed) {
+    res += "<ArrayBuffer: [";
+
+    int display_length = std::min<int>(byte_length, options->array_length);
+    res += v8()->LoadBytes(display_length, data, err);
+
+    if (display_length < byte_length) {
+      res += " ...";
+    }
+    res += " ]>";
+  } else {
+    snprintf(tmp, sizeof(tmp),
+             "<ArrayBuffer: backingStore=0x%016" PRIx64 ", byteLength=%d>",
+             data, byte_length);
+    res += tmp;
+  }
+
+  return res;
 }
 
 
-std::string JSArrayBufferView::Inspect(Error& err) {
+std::string JSArrayBufferView::Inspect(InspectOptions* options, Error& err) {
   JSArrayBuffer buf = Buffer(err);
   if (err.Fail()) return std::string();
 
@@ -1111,11 +1148,28 @@ std::string JSArrayBufferView::Inspect(Error& err) {
   Smi length = ByteLength(err);
   if (err.Fail()) return std::string();
 
+  int byte_length = static_cast<int>(length.GetValue());
+  int byte_offset = static_cast<int>(off.GetValue());
+  std::string res;
   char tmp[128];
-  snprintf(tmp, sizeof(tmp), "<ArrayBufferView 0x%016" PRIx64 "+%d:%d>", data,
-           static_cast<int>(off.GetValue()),
-           static_cast<int>(length.GetValue()));
-  return tmp;
+
+  if (options->detailed) {
+    res += "<ArrayBufferView: [";
+
+    int display_length = std::min<int>(byte_length, options->array_length);
+
+    res += v8()->LoadBytes(display_length, data + byte_offset, err);
+    if (display_length < byte_length) {
+      res += " ...";
+    }
+    res += " ]>";
+  } else {
+    snprintf(tmp, sizeof(tmp),
+             "<ArrayBufferView: backingStore=0x%016" PRIx64 ", byteOffset=%d, byteLength=%d>",
+             data, byte_offset, byte_length);
+    res += tmp;
+  }
+  return res;
 }
 
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -404,7 +404,8 @@ class JSArrayBuffer : public HeapObject {
 
   inline bool WasNeutered(Error& err);
 
-  std::string Inspect(Error& err);
+  std::string Inspect(InspectOptions* options, Error& err);
+  
 };
 
 class JSArrayBufferView : public HeapObject {
@@ -415,7 +416,7 @@ class JSArrayBufferView : public HeapObject {
   inline Smi ByteOffset(Error& err);
   inline Smi ByteLength(Error& err);
 
-  std::string Inspect(Error& err);
+  std::string Inspect(InspectOptions* options, Error& err);
 };
 
 class JSFrame : public Value {
@@ -450,6 +451,7 @@ class LLV8 {
   int64_t LoadConstant(const char* name);
   int64_t LoadPtr(int64_t addr, Error& err);
   double LoadDouble(int64_t addr, Error& err);
+  std::string LoadBytes(int64_t length, int64_t addr, Error& err);
   std::string LoadString(int64_t addr, int64_t length, Error& err);
   std::string LoadTwoByteString(int64_t addr, int64_t length, Error& err);
   uint8_t* LoadChunk(int64_t addr, int64_t length, Error& err);

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -30,9 +30,13 @@ function closure() {
   c.hashmap['cons-string'] += c.hashmap['cons-string'];
   c.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
   c.hashmap['long-array'] = new Array(20).fill(5);
-  c.hashmap['array-buffer'] = new Uint8Array([1, 2, 3, 4, 5]).buffer;
-  c.hashmap['uint8-array'] = new Uint8Array([1, 8, 32, 64, 128, 255]);
-  c.hashmap['buffer'] = Buffer.from([255, 128, 64, 32, 8, 1]);
+  c.hashmap['array-buffer'] = new Uint8Array(
+    [0x01, 0x02, 0x03, 0x04, 0x05]
+  ).buffer;
+  c.hashmap['uint8-array'] = new Uint8Array(
+    [0x01, 0x40, 0x60, 0x80, 0xf0, 0xff]
+  );
+  c.hashmap['buffer'] = Buffer.from([0xff, 0xf0, 0x80, 0x0f, 0x01, 0x00]);
 
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -30,6 +30,9 @@ function closure() {
   c.hashmap['cons-string'] += c.hashmap['cons-string'];
   c.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
   c.hashmap['long-array'] = new Array(20).fill(5);
+  c.hashmap['array-buffer'] = new Uint8Array([1, 2, 3, 4, 5]).buffer;
+  c.hashmap['uint8-array'] = new Uint8Array([1, 8, 32, 64, 128, 255]);
+  c.hashmap['buffer'] = Buffer.from([255, 128, 64, 32, 8, 1]);
 
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -50,6 +50,9 @@ tape('v8 inspect', (t) => {
   let arrowFunc = null;
   let array = null;
   let longArray = null;
+  let arrayBuffer = null;
+  let uint8Array = null;
+  let buffer = null;
 
   sess.wait(/Object/, (line) => {
     t.notEqual(line.indexOf(hashmap), -1, 'addr of `Object` should match');
@@ -83,6 +86,26 @@ tape('v8 inspect', (t) => {
         lines.match(/.long-array=(0x[0-9a-f]+):<Array: length=20>/);
     t.ok(longArrayMatch, '.array JSArray property');
     longArray = longArrayMatch[1];
+
+    const arrayBufferRe = new RegExp('.array-buffer=(0x[0-9a-f]+):' +
+      '<ArrayBuffer: backingStore=0x[0-9a-f]+, byteLength=5>');
+    const arrayBufferMatch = lines.match(arrayBufferRe);
+    t.ok(arrayBufferMatch, '.array-buffer JSArrayBuffer property');
+    arrayBuffer = arrayBufferMatch[1];
+
+    const uint8ArrayRe = new RegExp('.uint8-array=(0x[0-9a-f]+):' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6>');
+    const uint8ArrayMatch = lines.match(uint8ArrayRe);
+    t.ok(uint8ArrayMatch, '.uint8-array JSArrayBufferView property');
+    uint8Array = uint8ArrayMatch[1];
+
+    const bufferRe = new RegExp('.buffer=(0x[0-9a-f]+):' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6>');
+    const bufferMatch = lines.match(bufferRe);
+    t.ok(bufferMatch, '.buffer JSArrayBufferView property');
+    buffer = bufferMatch[1];
 
     const consMatch = lines.match(
         /.cons-string=(0x[0-9a-f]+):<String: "this could be a ...">/);
@@ -139,11 +162,66 @@ tape('v8 inspect', (t) => {
         lines.indexOf('<Array: length=20'),
         -1,
         'long array length');
+      t.ok(
+          lines.match(/\[9\]=<Smi: 5>}>$/),
+          'long array content');
+      sess.send(`v8 inspect ${arrayBuffer}`);
+  });
+
+  sess.linesUntil(/\]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBuffer: \[ 1, 2, 3, 4, 5 ]>$/;
     t.ok(
-        lines.match(/\[9\]=<Smi: 5>}>$/),
-        'long array content');
+        re.test(lines),
+        'array buffer content');
+    sess.send(`v8 inspect --array-length 1 ${arrayBuffer}`);
+  });
+
+  sess.linesUntil(/]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBuffer: \[ 1 ... ]>$/;
+    t.ok(
+        re.test(lines),
+        'array buffer content with maximum length 1');
+    sess.send(`v8 inspect ${uint8Array}`);
+  });
+
+  sess.linesUntil(/]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 1, 8, 32, 64, 128, 255 ]>$/;
+    t.ok(
+        re.test(lines),
+        'typed array content');
+    sess.send(`v8 inspect --array-length 1 ${uint8Array}`);
+  });
+
+  sess.linesUntil(/]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 1 ... ]>$/;
+    t.ok(
+        re.test(lines),
+        'typed array content with maximum length 1');
+    sess.send(`v8 inspect ${buffer}`);
+  });
+
+  sess.linesUntil(/]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 255, 128, 64, 32, 8, 1 ]>$/;
+    t.ok(
+        re.test(lines),
+        'buffer content');
+    sess.send(`v8 inspect --array-length 1 ${buffer}`);
+  });
+
+  sess.linesUntil(/]>/, (lines) => {
+    lines = lines.join('\n');
+    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 255 ... ]>$/;
+    t.ok(
+        re.test(lines),
+        'buffer content with maximum length 1');
     sess.send(`v8 inspect -s ${arrowFunc}`);
   });
+
 
   sess.linesUntil(/^>/, (lines) => {
     lines = lines.join('\n');

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -170,7 +170,11 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/\]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBuffer: \[ 1, 2, 3, 4, 5 ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBuffer: backingStore=0x[0-9a-f]+, byteLength=5: \\[\n' +
+      '  01, 02, 03, 04, 05\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'array buffer content');
@@ -179,7 +183,11 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBuffer: \[ 1 ... ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBuffer: backingStore=0x[0-9a-f]+, byteLength=5: \\[\n' +
+      '  01 ...\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'array buffer content with maximum length 1');
@@ -188,7 +196,12 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 1, 8, 32, 64, 128, 255 ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6: \\[\n' +
+      '  01, 40, 60, 80, f0, ff\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'typed array content');
@@ -197,7 +210,12 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 1 ... ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6: \\[\n' +
+      '  01 ...\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'typed array content with maximum length 1');
@@ -206,7 +224,12 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 255, 128, 64, 32, 8, 1 ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6: \\[\n' +
+      '  ff, f0, 80, 0f, 01, 00\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'buffer content');
@@ -215,7 +238,12 @@ tape('v8 inspect', (t) => {
 
   sess.linesUntil(/]>/, (lines) => {
     lines = lines.join('\n');
-    const re = /0x[0-9a-f]+:<ArrayBufferView: \[ 255 ... ]>$/;
+    const re = new RegExp(
+      '0x[0-9a-f]+:' +
+      '<ArrayBufferView: backingStore=0x[0-9a-f]+, byteOffset=\\d+, ' +
+      'byteLength=6: \\[\n' +
+      '  ff ...\n' +
+      ']>');
     t.ok(
         re.test(lines),
         'buffer content with maximum length 1');


### PR DESCRIPTION
This PR adds support for reading contents from array buffers, typed arrays, and Node buffers (since they are Uint8Arrays).

This currently prints the content like this:

```
(lldb) v8 inspect 0x00000c20705a94c9
0x00000c20705a94c9:<Object: Object elements {
    [0]=0x00003ea02c904211:<null>,
    [4]=0x00003ea02c904241:<undefined>,
    [23]=0x00000c20705aa9a1:<JSRegExp source=/regexp/>,
    [25]=0x00001a9002c04cb1:<function: c.hashmap.(anonymous function) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:40:19>}
  properties {
    .some-key=<Smi: 42>,
    .other-key=0x000002ecfb6c8379:<String: "ohai">,
    .cons-string=0x00000c20705a9669:<String: "this could be a ...">,
    .array=0x00000c20705a96f1:<Array: length=6>,
    .long-array=0x00000c20705a97e1:<Array: length=20>,
    .array-buffer=0x00000c20705aa269:<ArrayBuffer: backingStore=0x00000001030012d0, byteLength=5>,
    .uint8-array=0x00000c20705aa3c9:<ArrayBufferView: backingStore=0x0000000103002b70, byteOffset=0, byteLength=6>,
    .buffer=0x00000c20705aa6b1:<ArrayBufferView: backingStore=0x0000000104007200, byteOffset=1296, byteLength=6>,
    .scoped=0x00001a9002c09921:<function: name at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:48:35>}>
(lldb) v8 inspect 0x00000c20705aa269
0x00000c20705aa269:<ArrayBuffer: [ 1, 2, 3, 4, 5 ]>
(lldb) v8 inspect 0x00000c20705aa3c9
0x00000c20705aa3c9:<ArrayBufferView: [ 1, 8, 32, 64, 128, 255 ]>
(lldb) v8 inspect 0x00000c20705aa6b1
0x00000c20705aa6b1:<ArrayBufferView: [ 255, 128, 64, 32, 8, 1 ]>
```

I have changed the non-detail view of these objects to show the names of each field, so it's now `<ArrayBufferView: backingStore=0x0000000104007200, byteOffset=1296, byteLength=6>` instead of `<ArrayBufferView 0x0000000104007200+1296:6>`.

The detailed view currently just prints the content byte by byte separated by commas in one line. At the moment it does not handle endianness, nor does it "merges" the bytes for typed arrays with types other than Uint8, but that can be worked on later.

Also currently it just prints the bytes in decimals like what you get when doing `util.inspect` on typed arrays in Node.js, I don't have an opinion on what format it's supposed to be, so feel free to give suggestions (e.g. print hexidemals or print it line by line like what `memory read` in lldb does)

Fixes: https://github.com/nodejs/llnode/issues/89

cc: @bnoordhuis 

Tested on Mac OS 10.12.4 with Node v6.11.1, v4.8.4 and v8.1.4