### PR TITLE
src: Add support for big endian systems

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -200,7 +200,7 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   v8::Error err;
   std::string res = v8_value.Inspect(&inspect_options, err);
   if (err.Fail()) {
-    result.SetError("Failed to evaluate expression");
+    result.SetError(err.GetMessage());
     return false;
   }
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1264,8 +1264,7 @@ void LLScan::ScanMemoryRanges(FindJSObjectsVisitor& v) {
           if (process_byte_order != HOST_BYTE_ORDER) {
             value = __builtin_bswap32(value);
           }
-        }
-        else if (addr_size == 8) {
+        } else if (addr_size == 8) {
           value = *reinterpret_cast<uint64_t*>(&block[j]);
           if (process_byte_order != HOST_BYTE_ORDER) {
             value = __builtin_bswap64(value);

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -20,6 +20,7 @@ using lldb::SBSymbolContext;
 using lldb::SBSymbolContextList;
 using lldb::SBTarget;
 using lldb::addr_t;
+using lldb::ByteOrder;
 
 static std::string kConstantPrefix = "v8dbg_";
 
@@ -68,18 +69,15 @@ static int64_t LookupConstant(SBTarget target, const char* name, int64_t def,
 
   // NOTE: size could be bigger for at the end symbols
   if (size >= 8) {
-    process.ReadMemory(addr, &res, 8, sberr);
+    res = process.ReadUnsignedFromMemory(addr, 8, sberr);
   } else if (size == 4) {
-    int32_t tmp;
-    process.ReadMemory(addr, &tmp, size, sberr);
+    int32_t tmp = process.ReadUnsignedFromMemory(addr, size, sberr);
     res = static_cast<int64_t>(tmp);
   } else if (size == 2) {
-    int16_t tmp;
-    process.ReadMemory(addr, &tmp, size, sberr);
+    int16_t tmp = process.ReadUnsignedFromMemory(addr, size, sberr);
     res = static_cast<int64_t>(tmp);
   } else if (size == 1) {
-    int8_t tmp;
-    process.ReadMemory(addr, &tmp, size, sberr);
+    int8_t tmp = process.ReadUnsignedFromMemory(addr, size, sberr);
     res = static_cast<int64_t>(tmp);
   } else {
     err = Error::Failure("Unexpected symbol size");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -20,7 +20,6 @@ using lldb::SBSymbolContext;
 using lldb::SBSymbolContextList;
 using lldb::SBTarget;
 using lldb::addr_t;
-using lldb::ByteOrder;
 
 static std::string kConstantPrefix = "v8dbg_";
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -81,7 +81,8 @@ inline int64_t HeapObject::GetType(Error& err) {
 
 
 inline int64_t Map::GetType(Error& err) {
-  int64_t type = v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceAttrsOffset), 2, err);
+  int64_t type =
+      v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceAttrsOffset), 2, err);
   if (err.Fail()) return -1;
 
   return type & 0xff;
@@ -159,8 +160,9 @@ inline int64_t Map::InObjectProperties(Error& err) {
 }
 
 inline int64_t Map::InstanceSize(Error& err) {
-  return v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceSizeOffset), 1, err)
-      * v8()->common()->kPointerSize;
+  return v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceSizeOffset), 1,
+                            err) *
+         v8()->common()->kPointerSize;
 }
 
 ACCESSOR(JSObject, Properties, js_object()->kPropertiesOffset, HeapObject)

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -83,6 +83,12 @@ inline int64_t HeapObject::GetType(Error& err) {
 inline int64_t Map::GetType(Error& err) {
   int64_t type = LoadField(v8()->map()->kInstanceAttrsOffset, err);
   if (err.Fail()) return -1;
+
+  if( v8()->process_.GetByteOrder() != HOST_BYTE_ORDER) {
+    // The type is only one byte within the instance attrs.
+    type = type >> 0x30;
+  }
+
   return type & 0xff;
 }
 
@@ -150,7 +156,7 @@ ACCESSOR(Map, InstanceDescriptors, map()->kInstanceDescriptorsOffset,
          HeapObject)
 
 inline int64_t Map::BitField3(Error& err) {
-  return LoadField(v8()->map()->kBitField3Offset, err) & 0xffffffff;
+  return v8()->LoadUnsigned(LeaField(v8()->map()->kBitField3Offset), 4, err);
 }
 
 inline int64_t Map::InObjectProperties(Error& err) {
@@ -158,8 +164,8 @@ inline int64_t Map::InObjectProperties(Error& err) {
 }
 
 inline int64_t Map::InstanceSize(Error& err) {
-  return (LoadField(v8()->map()->kInstanceSizeOffset, err) & 0xff) *
-         v8()->common()->kPointerSize;
+  return v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceSizeOffset), 1, err)
+      * v8()->common()->kPointerSize;
 }
 
 ACCESSOR(JSObject, Properties, js_object()->kPropertiesOffset, HeapObject)

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -81,13 +81,8 @@ inline int64_t HeapObject::GetType(Error& err) {
 
 
 inline int64_t Map::GetType(Error& err) {
-  int64_t type = LoadField(v8()->map()->kInstanceAttrsOffset, err);
+  int64_t type = v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceAttrsOffset), 2, err);
   if (err.Fail()) return -1;
-
-  if( v8()->process_.GetByteOrder() != HOST_BYTE_ORDER) {
-    // The type is only one byte within the instance attrs.
-    type = type >> 0x30;
-  }
 
   return type & 0xff;
 }

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -73,6 +73,22 @@ int64_t LLV8::LoadPtr(int64_t addr, Error& err) {
 }
 
 
+int64_t LLV8::LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err) {
+  SBError sberr;
+  int64_t value = process_.ReadUnsignedFromMemory(static_cast<addr_t>(addr),
+                                                  byte_size, sberr);
+
+  if (sberr.Fail()) {
+    // TODO(indutny): add more information
+    err = Error::Failure("Failed to load V8 value");
+    return -1;
+  }
+
+  err = Error::Ok();
+  return value;
+}
+
+
 double LLV8::LoadDouble(int64_t addr, Error& err) {
   SBError sberr;
   int64_t value = process_.ReadUnsignedFromMemory(static_cast<addr_t>(addr),

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -7,6 +7,14 @@
 
 #include "src/llv8-constants.h"
 
+using lldb::ByteOrder;
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define HOST_BYTE_ORDER ByteOrder::eByteOrderLittle
+#else
+#define HOST_BYTE_ORDER ByteOrder::eByteOrderBig
+#endif
+
 namespace llnode {
 
 class FindJSObjectsVisitor;
@@ -462,6 +470,7 @@ class LLV8 {
 
   int64_t LoadConstant(const char* name);
   int64_t LoadPtr(int64_t addr, Error& err);
+  int64_t LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err);
   double LoadDouble(int64_t addr, Error& err);
   std::string LoadBytes(int64_t length, int64_t addr, Error& err);
   std::string LoadString(int64_t addr, int64_t length, Error& err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -7,14 +7,6 @@
 
 #include "src/llv8-constants.h"
 
-using lldb::ByteOrder;
-
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define HOST_BYTE_ORDER ByteOrder::eByteOrderLittle
-#else
-#define HOST_BYTE_ORDER ByteOrder::eByteOrderBig
-#endif
-
 namespace llnode {
 
 class FindJSObjectsVisitor;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -9,7 +9,7 @@
 
 using lldb::ByteOrder;
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER == __ORDER_LITTLE_ENDIAN__
 #define HOST_BYTE_ORDER ByteOrder::eByteOrderLittle
 #else
 #define HOST_BYTE_ORDER ByteOrder::eByteOrderBig

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -9,7 +9,7 @@
 
 using lldb::ByteOrder;
 
-#if __BYTE_ORDER == __ORDER_LITTLE_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define HOST_BYTE_ORDER ByteOrder::eByteOrderLittle
 #else
 #define HOST_BYTE_ORDER ByteOrder::eByteOrderBig


### PR DESCRIPTION
Read values correctly converting for endianess as required.
Generally this just means using LLDB's `ReadUnsignedFromMemory` function but there are a few places where we need optimise reading values and where we only want one byte from a larger field where we need to account for endianess ourselves.

I've tested this with z/Linux core dumps and it enables commands like `v8 findjsobjects`, `findjsinstances` and `v8 inspect` to work. (I've used llnode with these changes to open the z/Linux dumps on my Mac.)

`v8 bt` does not work but that is due to a separate issue with how v8 stacks are implemented on non-x86 systems.

I've verified the tests still pass which confirms these changes don't break little endian support.