### PR TITLE
src: support thin strings and stub frames

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -136,7 +136,8 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
       lldb::SBMemoryRegionInfo info;
       if (target.GetProcess().GetMemoryRegionInfo(pc, info).Success() &&
           info.IsExecutable() && info.IsWritable()) {
-        result.Printf("  %c frame #%u: 0x%016" PRIx64 " <builtin>\n", star, i, pc);
+        result.Printf("  %c frame #%u: 0x%016" PRIx64 " <builtin>\n", star, i,
+                      pc);
         continue;
       }
     }

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -617,6 +617,14 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
       result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
                     type_name.c_str(), "<Second>", search_value_.raw());
     }
+  } else if (repr == v8->string()->kThinStringTag) {
+    v8::ThinString thin_str(str);
+    v8::String actual = thin_str.Actual(err);
+    if (err.Success() && actual.raw() == search_value_.raw()) {
+      std::string type_name = thin_str.GetTypeName(err);
+      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+                    type_name.c_str(), "<Actual>", search_value_.raw());
+    }
   }
   // Nothing to do for other kinds of string.
 }
@@ -692,6 +700,14 @@ void FindReferencesCmd::ReferenceScanner::ScanRefs(v8::String& str,
     v8::String second = cons_str.Second(err);
     if (err.Success() && first.raw() != second.raw()) {
       references = llscan.GetReferencesByValue(second.raw());
+      references->push_back(str.raw());
+    }
+  } else if (repr == v8->string()->kThinStringTag) {
+    v8::ThinString thin_str(str);
+    v8::String actual = thin_str.Actual(err);
+
+    if (err.Success()) {
+      references = llscan.GetReferencesByValue(actual.raw());
       references->push_back(str.raw());
     }
   }

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -334,6 +334,7 @@ void String::Load() {
   kConsStringTag = LoadConstant("ConsStringTag");
   kSlicedStringTag = LoadConstant("SlicedStringTag");
   kExternalStringTag = LoadConstant("ExternalStringTag");
+  kThinStringTag = LoadConstant("ThinStringTag");
 
   kLengthOffset = LoadConstant("class_String__length__SMI");
 }
@@ -362,6 +363,9 @@ void SlicedString::Load() {
   kOffsetOffset = LoadConstant("class_SlicedString__offset__SMI");
 }
 
+void ThinString::Load() {
+  kActualOffset = LoadConstant("class_ThinString__actual__String");
+}
 
 void FixedArrayBase::Load() {
   kLengthOffset = LoadConstant("class_FixedArrayBase__length__SMI");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -522,6 +522,7 @@ void Frame::Load() {
   kConstructFrame = LoadConstant("frametype_ConstructFrame");
   kJSFrame = LoadConstant("frametype_JavaScriptFrame");
   kOptimizedFrame = LoadConstant("frametype_OptimizedFrame");
+  kStubFrame = LoadConstant("frametype_StubFrame");
 }
 
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -248,6 +248,7 @@ class String : public Module {
   int64_t kConsStringTag;
   int64_t kSlicedStringTag;
   int64_t kExternalStringTag;
+  int64_t kThinStringTag;
 
   int64_t kLengthOffset;
 
@@ -292,6 +293,16 @@ class SlicedString : public Module {
 
   int64_t kParentOffset;
   int64_t kOffsetOffset;
+
+ protected:
+  void Load();
+};
+
+class ThinString : public Module {
+ public:
+  MODULE_DEFAULT_METHODS(ThinString);
+
+  int64_t kActualOffset;
 
  protected:
   void Load();

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -452,6 +452,7 @@ class Frame : public Module {
   int64_t kConstructFrame;
   int64_t kJSFrame;
   int64_t kOptimizedFrame;
+  int64_t kStubFrame;
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -272,6 +272,8 @@ ACCESSOR(ConsString, Second, cons_string()->kSecondOffset, String);
 ACCESSOR(SlicedString, Parent, sliced_string()->kParentOffset, String);
 ACCESSOR(SlicedString, Offset, sliced_string()->kOffsetOffset, Smi);
 
+ACCESSOR(ThinString, Actual, thin_string()->kActualOffset, String);
+
 ACCESSOR(FixedArrayBase, Length, fixed_array_base()->kLengthOffset, Smi);
 
 inline std::string OneByteString::ToString(Error& err) {
@@ -317,6 +319,16 @@ inline std::string SlicedString::ToString(Error& err) {
   if (err.Fail()) return std::string();
 
   return tmp.substr(offset.GetValue(), length.GetValue());
+}
+
+inline std::string ThinString::ToString(Error& err) {
+  String actual = Actual(err);
+  if (err.Fail()) return std::string();
+
+  std::string tmp = actual.ToString(err);
+  if (err.Fail()) return std::string();
+
+  return tmp;
 }
 
 inline int64_t FixedArray::LeaData() const {

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -267,6 +267,8 @@ std::string JSFrame::Inspect(bool with_args, Error& err) {
       return "<internal>";
     } else if (value == v8()->frame()->kConstructFrame) {
       return "<constructor>";
+    } else if (value == v8()->frame()->kStubFrame) {
+      return "<stub>";
     } else if (value != v8()->frame()->kJSFrame &&
                value != v8()->frame()->kOptimizedFrame) {
       err = Error::Failure("Unknown frame marker");

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <algorithm>
 
 #include "llv8-inl.h"
 #include "llv8.h"
@@ -43,6 +42,7 @@ void LLV8::Load(SBTarget target) {
   two_byte_string.Assign(target, &common);
   cons_string.Assign(target, &common);
   sliced_string.Assign(target, &common);
+  thin_string.Assign(target, &common);
   fixed_array_base.Assign(target, &common);
   fixed_array.Assign(target, &common);
   oddball.Assign(target, &common);
@@ -90,8 +90,7 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
 std::string LLV8::LoadBytes(int64_t length, int64_t addr, Error& err) {
   uint8_t* buf = new uint8_t[length + 1];
   SBError sberr;
-  process_.ReadMemory(addr, buf,
-                      static_cast<size_t>(length), sberr);
+  process_.ReadMemory(addr, buf, static_cast<size_t>(length), sberr);
   if (sberr.Fail()) {
     err = Error::Failure("Failed to load V8 raw buffer");
     delete[] buf;
@@ -957,6 +956,11 @@ std::string String::ToString(Error& err) {
     return std::string("(external)");
   }
 
+  if (repr == v8()->string()->kThinStringTag) {
+    ThinString thin(this);
+    return thin.ToString(err);
+  }
+
   err = Error::Failure("Unsupported string representation");
   return std::string();
 }
@@ -1111,9 +1115,9 @@ std::string JSArrayBuffer::Inspect(InspectOptions* options, Error& err) {
 
   char tmp[128];
   snprintf(tmp, sizeof(tmp),
-           "<ArrayBuffer: backingStore=0x%016" PRIx64 ", byteLength=%d",
-           data, byte_length);
-  
+           "<ArrayBuffer: backingStore=0x%016" PRIx64 ", byteLength=%d", data,
+           byte_length);
+
   std::string res;
   res += tmp;
   if (options->detailed) {
@@ -1156,7 +1160,8 @@ std::string JSArrayBufferView::Inspect(InspectOptions* options, Error& err) {
   int byte_offset = static_cast<int>(off.GetValue());
   char tmp[128];
   snprintf(tmp, sizeof(tmp),
-           "<ArrayBufferView: backingStore=0x%016" PRIx64 ", byteOffset=%d, byteLength=%d",
+           "<ArrayBufferView: backingStore=0x%016" PRIx64
+           ", byteOffset=%d, byteLength=%d",
            data, byte_offset, byte_length);
 
   std::string res;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -221,6 +221,15 @@ class SlicedString : public String {
   inline std::string ToString(Error& err);
 };
 
+class ThinString : public String {
+ public:
+  V8_VALUE_DEFAULT_METHODS(ThinString, String)
+
+  inline String Actual(Error& err);
+
+  inline std::string ToString(Error& err);
+};
+
 class HeapNumber : public HeapObject {
  public:
   V8_VALUE_DEFAULT_METHODS(HeapNumber, HeapObject)
@@ -405,7 +414,6 @@ class JSArrayBuffer : public HeapObject {
   inline bool WasNeutered(Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);
-  
 };
 
 class JSArrayBufferView : public HeapObject {
@@ -477,6 +485,7 @@ class LLV8 {
   constants::TwoByteString two_byte_string;
   constants::ConsString cons_string;
   constants::SlicedString sliced_string;
+  constants::ThinString thin_string;
   constants::FixedArrayBase fixed_array_base;
   constants::FixedArray fixed_array;
   constants::Oddball oddball;
@@ -503,6 +512,7 @@ class LLV8 {
   friend class TwoByteString;
   friend class ConsString;
   friend class SlicedString;
+  friend class ThinString;
   friend class HeapNumber;
   friend class JSObject;
   friend class JSArray;

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -8,6 +8,13 @@ let outerVar = 'outer variable';
 
 exports.holder = {};
 
+function makeThin(a, b) {
+  var str = a + b;
+  var obj = {};
+  obj[str];  // Turn the cons string into a thin string.
+  return str;
+}
+
 function closure() {
 
   function Class() {
@@ -28,6 +35,9 @@ function closure() {
   c.hashmap['cons-string'] =
       'this could be a bit smaller, but v8 wants big str.';
   c.hashmap['cons-string'] += c.hashmap['cons-string'];
+  c.hashmap['internalized-string'] = 'foobar';
+  // This thin string points to the previous 'foobar'.
+  c.hashmap['thin-string'] = makeThin('foo', 'bar');
   c.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
   c.hashmap['long-array'] = new Array(20).fill(5);
   c.hashmap['array-buffer'] = new Uint8Array(

--- a/test/frame-test.js
+++ b/test/frame-test.js
@@ -18,7 +18,7 @@ tape('v8 stack', (t) => {
     // FIXME(bnoordhuis) This can fail with versions of lldb that don't
     // support the GetMemoryRegions() API; llnode won't be able to identify
     // V8 builtins stack frames, it just prints them as anonymous frames.
-    lines = lines.filter((s) => !/<builtin>/.test(s));
+    lines = lines.filter((s) => !/<builtin>|<stub>/.test(s));
     const eyecatcher = lines[0];
     const adapter = lines[1];
     const crasher = lines[2];

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -47,6 +47,7 @@ tape('v8 inspect', (t) => {
 
   let regexp = null;
   let cons = null;
+  let thin = null;
   let arrowFunc = null;
   let array = null;
   let longArray = null;
@@ -112,6 +113,11 @@ tape('v8 inspect', (t) => {
     t.ok(consMatch, '.cons-string ConsString property');
     cons = consMatch[1];
 
+    const thinMatch = lines.match(
+        /.thin-string=(0x[0-9a-f]+):<String: "foobar">/);
+    t.ok(thinMatch, '.thin-string ThinString property');
+    thin = thinMatch[1];
+
     sess.send(`v8 inspect ${regexp}`);
     sess.send(`v8 inspect -F ${cons}`);
   });
@@ -140,6 +146,15 @@ tape('v8 inspect', (t) => {
         lines.indexOf('this could be a bit ...'),
         -1,
         '--string-length truncates the string');
+
+    sess.send(`v8 inspect ${thin}`);
+  });
+
+  sess.linesUntil(/">/, (lines) => {
+    lines = lines.join('\n');
+    t.ok(
+      /0x[0-9a-f]+:<String: "foobar">/.test(lines),
+      'thin string content');
 
     sess.send(`v8 inspect ${array}`);
   });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/llnode/issues/117

In Node.js v8.3.0 Turbofan has been enabled by default, so thin strings have also been enabled and now Turbofan would put stub frames on the stack (to store register states for bytecode handlers, I think).

Before this change, when viewing the backtrace of `test/fixtures/inspect-scenario.js` with Node.js v8.3.0, frames containing functions with thin string arguments or in thin string paths would be broken:

<details><summary>See backtrace of inspect-scenario.js</summary>

```
 * thread #1: tid = 0x81d450, 0x0000000100bbe942 node`v8::base::OS::Abort() at platform-posix.cc:261, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x0000000100bbe942 node`v8::base::OS::Abort() at platform-posix.cc:261 [opt]
    frame #1: 0x00000001008a27cb node`v8::internal::Runtime_Throw(int, v8::internal::Object**, v8::internal::Isolate*) [inlined] v8::internal::__RT_impl_Runtime_Throw(v8::internal::Arguments, v8::internal::Isolate*) at runtime-internal.cc:74 [opt]
    frame #2: 0x00000001008a27aa node`v8::internal::Runtime_Throw(args_length=<unavailable>, args_object=<unavailable>, isolate=0x00000001030492e0) at runtime-internal.cc:71 [opt]
    frame #3: 0x00001a1235b840dd <exit>
    frame #4: 0x00001a1235c8523a
    frame #5: 0x00001a1235b92f12 method(this=0x00002976af95c089:<Object: Class>) at (no script):20:43 fn=0x000026033eb8f931
    frame #6: 0x00001a1235c735e9
    frame #7: 0x00001a1235b92f12 closure(this=0x000022d8c1402241:<undefined>) at (no script):11:17 fn=0x00002976af905ad9
    frame #8: 0x00001a1235c73fa1
    frame #9: 0x00001a1235b92f12
    frame #10: 0x00001a1235c72cc8
    frame #11: 0x00001a1235b92f12
    frame #12: 0x00001a1235c738aa
    frame #13: 0x00001a1235b92f12
    frame #14: 0x00001a1235c738aa
    frame #15: 0x00001a1235b92f12
    frame #16: 0x00001a1235c7373c
    frame #17: 0x00001a1235b92f12
    frame #18: 0x00001a1235c74242
    frame #19: 0x00001a1235b92f12 Module._load(this=0x0000135cdc0bb3b1:<function: Module at module.js:55:16>, 0x0000135cdc0c7119:<String: "/Users/joyee/pro...">, 0x000022d8c1402211:<null>, 0x000022d8c14022c1:<true>) at module.js:434:24 fn=0x000012d14eec2e29
    frame #20: 0x00001a1235c72cc8
    frame #21: 0x00001a1235b92f12 Module.runMain(this=0x0000135cdc0bb3b1:<function: Module at module.js:55:16>) at module.js:607:26 fn=0x000012d14eec3099
    frame #22: 0x00001a1235c93c29
    frame #23: 0x00001a1235b92f12 startup(this=0x000022d8c1402241:<undefined>) at bootstrap_node.js:1:10 fn=0x0000304c372feb79
    frame #24: 0x00001a1235c73fa1
    frame #25: 0x00001a1235b92f12 (anonymous)(this=0x000022d8c1402211:<null>, 0x0000304c372febf9:<Object: process>) at bootstrap_node.js:1:10 fn=0x0000304c372fec49
    frame #26: 0x00001a1235b90650 <internal>
    frame #27: 0x00001a1235c64ead <entry>
    frame #28: 0x00000001005daed1 node`v8::internal::(anonymous namespace)::Invoke(isolate=0x0000000000000049, is_construct=<unavailable>, target=<unavailable>, receiver=<unavailable>, argc=1, args=<unavailable>, new_target=<unavailable>, message_handling=<unavailable>) at execution.cc:145 [opt]
    frame #29: 0x00000001005dabb9 node`v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [inlined] v8::internal::(anonymous namespace)::CallInternal(message_handling=kReport) at execution.cc:181 [opt]
    frame #30: 0x00000001005dab30 node`v8::internal::Execution::Call(isolate=0x0000000103000c00, callable=Handle<v8::internal::Object> @ r12, receiver=<unavailable>, argc=1, argv=<unavailable>) at execution.cc:191 [opt]
    frame #31: 0x0000000100204b98 node`v8::Function::Call(this=0x0000000103049238, context=<unavailable>, recv=<unavailable>, argc=1, argv=0x00007fff5fbfe1f0) at api.cc:5279 [opt]
    frame #32: 0x0000000100a4d083 node`node::LoadEnvironment(env=0x00007fff5fbfe290) at node.cc:3613 [opt]
    frame #33: 0x0000000100a53de8 node`node::Start(isolate=0x0000000103000c00, isolate_data=<unavailable>, argc=2, argv=<unavailable>, exec_argc=1, exec_argv=0x0000000102503c70) at node.cc:4528 [opt]
    frame #34: 0x0000000100a4e9a0 node`node::Start(event_loop=0x000000010154ef90, argc=2, argv=0x00000001025043a0, exec_argc=<unavailable>, exec_argv=<unavailable>) at node.cc:4607 [opt]
    frame #35: 0x0000000100a4e62d node`node::Start(argc=<unavailable>, argv=0x00000001025043a0) at node.cc:4662 [opt]
    frame #36: 0x0000000100001434 node`start + 52
```
</details>


After (with patch in https://github.com/nodejs/llnode/issues/117#issuecomment-322034567):
<details><summary>See backtrace of inspect-scenario.js</summary>

```
 * thread #1: tid = 0x81cad8, 0x0000000100bbe942 node`v8::base::OS::Abort() at platform-posix.cc:261, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x0000000100bbe942 node`v8::base::OS::Abort() at platform-posix.cc:261 [opt]
    frame #1: 0x00000001008a27cb node`v8::internal::Runtime_Throw(int, v8::internal::Object**, v8::internal::Isolate*) [inlined] v8::internal::__RT_impl_Runtime_Throw(v8::internal::Arguments, v8::internal::Isolate*) at runtime-internal.cc:74 [opt]
    frame #2: 0x00000001008a27aa node`v8::internal::Runtime_Throw(args_length=<unavailable>, args_object=<unavailable>, isolate=0x00000001030492e0) at runtime-internal.cc:71 [opt]
    frame #3: 0x000016c7041040dd <exit>
    frame #4: 0x000016c70420523a <stub>
    frame #5: 0x000016c704112f12 method(this=0x00000a7bd42dc201:<Object: Class>) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:27:43 fn=0x00003aeebdc8faa9
    frame #6: 0x000016c7041f35e9 <stub>
    frame #7: 0x000016c704112f12 closure(this=0x0000156976502241:<undefined>) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:18:17 fn=0x00000a7bd4285c81
    frame #8: 0x000016c7041f3fa1 <stub>
    frame #9: 0x000016c704112f12 (anonymous)(this=0x00000a7bd4283a61:<Object: Object>, 0x00000a7bd4283a61:<Object: Object>, 0x00000a7bd42857e9:<function: require at (external).js:8:19>, 0x00000a7bd42839a1:<Object: Module>, 0x00000a7bd4282dd9:<String: "/Users/joyee/pro...">, 0x00000a7bd4285781:<String: "/Users/joyee/pro...">) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:1:10 fn=0x00000a7bd4285739
    frame #10: 0x000016c7041f2cc8 <stub>
    frame #11: 0x000016c704112f12 Module._compile(this=0x00000a7bd42839a1:<Object: Module>, 0x00000a7bd42847b1:<String: "'use strict';

c...">, 0x00000a7bd4282dd9:<String: "/Users/joyee/pro...">) at module.js:530:37 fn=0x0000170c90843011
    frame #12: 0x000016c7041f38aa <stub>
    frame #13: 0x000016c704112f12 Module._extensions..js(this=0x000037f6cb67e271:<Object: Object>, 0x00000a7bd42839a1:<Object: Module>, 0x00000a7bd4282dd9:<String: "/Users/joyee/pro...">) at module.js:582:37 fn=0x0000170c90843059
    frame #14: 0x000016c7041f38aa <stub>
    frame #15: 0x000016c704112f12 Module.load(this=0x00000a7bd42839a1:<Object: Module>, 0x00000a7bd4282dd9:<String: "/Users/joyee/pro...">) at module.js:498:33 fn=0x0000170c90842f81
    frame #16: 0x000016c7041f373c <stub>
    frame #17: 0x000016c704112f12 tryModuleLoad(this=0x0000156976502241:<undefined>, 0x00000a7bd42839a1:<Object: Module>, 0x00000a7bd4282dd9:<String: "/Users/joyee/pro...">) at module.js:467:23 fn=0x000037f6cb63b561
    frame #18: 0x000016c7041f4242 <stub>
    frame #19: 0x000016c704112f12 Module._load(this=0x000037f6cb63b3b1:<function: Module at module.js:55:16>, 0x000037f6cb647081:<String: "/Users/joyee/pro...">, 0x0000156976502211:<null>, 0x00001569765022c1:<true>) at module.js:434:24 fn=0x0000170c90842ec1
    frame #20: 0x000016c7041f2cc8 <stub>
    frame #21: 0x000016c704112f12 Module.runMain(this=0x000037f6cb63b3b1:<function: Module at module.js:55:16>) at module.js:607:26 fn=0x0000170c90843131
    frame #22: 0x000016c704213c29 <stub>
    frame #23: 0x000016c704112f12 startup(this=0x0000156976502241:<undefined>) at bootstrap_node.js:1:10 fn=0x000027f86ea7eb79
    frame #24: 0x000016c7041f3fa1 <stub>
    frame #25: 0x000016c704112f12 (anonymous)(this=0x0000156976502211:<null>, 0x000027f86ea7ebf9:<Object: process>) at bootstrap_node.js:1:10 fn=0x000027f86ea7ec49
    frame #26: 0x000016c704110650 <internal>
    frame #27: 0x000016c7041e4ead <entry>
    frame #28: 0x00000001005daed1 node`v8::internal::(anonymous namespace)::Invoke(isolate=0x0000000000000049, is_construct=<unavailable>, target=<unavailable>, receiver=<unavailable>, argc=1, args=<unavailable>, new_target=<unavailable>, message_handling=<unavailable>) at execution.cc:145 [opt]
    frame #29: 0x00000001005dabb9 node`v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [inlined] v8::internal::(anonymous namespace)::CallInternal(message_handling=kReport) at execution.cc:181 [opt]
    frame #30: 0x00000001005dab30 node`v8::internal::Execution::Call(isolate=0x0000000103000c00, callable=Handle<v8::internal::Object> @ r12, receiver=<unavailable>, argc=1, argv=<unavailable>) at execution.cc:191 [opt]
    frame #31: 0x0000000100204b98 node`v8::Function::Call(this=0x0000000103049238, context=<unavailable>, recv=<unavailable>, argc=1, argv=0x00007fff5fbfe1f0) at api.cc:5279 [opt]
    frame #32: 0x0000000100a4d083 node`node::LoadEnvironment(env=0x00007fff5fbfe290) at node.cc:3613 [opt]
    frame #33: 0x0000000100a53de8 node`node::Start(isolate=0x0000000103000c00, isolate_data=<unavailable>, argc=2, argv=<unavailable>, exec_argc=1, exec_argv=0x0000000102503c70) at node.cc:4528 [opt]
    frame #34: 0x0000000100a4e9a0 node`node::Start(event_loop=0x000000010154ef90, argc=2, argv=0x00000001025043a0, exec_argc=<unavailable>, exec_argv=<unavailable>) at node.cc:4607 [opt]
    frame #35: 0x0000000100a4e62d node`node::Start(argc=<unavailable>, argv=0x00000001025043a0) at node.cc:4662 [opt]
    frame #36: 0x0000000100001434 node`start + 52
```
</details>

Also display stub frames as `<stub>` to fix `frame-test.js`.

This would need a patch in v8 to get the `kThinStringTag` constant: https://github.com/nodejs/llnode/issues/117#issuecomment-322034567

Tested with v4.8.4, v6.11.1, v8.2.1 and v8.3.0(with patch from https://github.com/nodejs/llnode/issues/117#issuecomment-322034567)