### PR TITLE
llv8-inl.h: Fix crash on sliced external strings

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -309,6 +309,13 @@ inline std::string SlicedString::ToString(Error& err) {
   String parent = Parent(err);
   if (err.Fail()) return std::string();
 
+  // TODO - Remove when we add support for external strings
+  // We can't use the offset and length safely if we get "(external)"
+  // instead of the original parent string.
+  if (parent.Representation(err) == v8()->string()->kExternalStringTag) {
+    return parent.ToString(err);
+  }
+
   Smi offset = Offset(err);
   if (err.Fail()) return std::string();
 

--- a/test/common.js
+++ b/test/common.js
@@ -120,6 +120,7 @@ function Session(scenario) {
     '--',
     process.execPath,
     '--abort_on_uncaught_exception',
+    '--expose_externalize_string',
     path.join(exports.fixturesDir, scenario)
   ], {
     stdio: [ 'pipe', 'pipe', 'pipe' ],

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -38,6 +38,15 @@ function closure() {
   c.hashmap['internalized-string'] = 'foobar';
   // This thin string points to the previous 'foobar'.
   c.hashmap['thin-string'] = makeThin('foo', 'bar');
+  // Create an externalized string and slice it.
+  c.hashmap['externalized-string'] =
+    'string that will be externalized and sliced';
+  externalizeString(c.hashmap['externalized-string']);
+  // Sliced strings need to be longer that SlicedString::kMinLength
+  // which seems to be 13 so our string is 26.
+  c.hashmap['sliced-externalized-string'] =
+    c.hashmap['externalized-string'].substring(10,36);
+
   c.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
   c.hashmap['long-array'] = new Array(20).fill(5);
   c.hashmap['array-buffer'] = new Uint8Array(

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -40,12 +40,12 @@ function closure() {
   c.hashmap['thin-string'] = makeThin('foo', 'bar');
   // Create an externalized string and slice it.
   c.hashmap['externalized-string'] =
-    'string that will be externalized and sliced';
+      'string that will be externalized and sliced';
   externalizeString(c.hashmap['externalized-string']);
   // Sliced strings need to be longer that SlicedString::kMinLength
   // which seems to be 13 so our string is 26.
   c.hashmap['sliced-externalized-string'] =
-    c.hashmap['externalized-string'].substring(10,36);
+      c.hashmap['externalized-string'].substring(10,36);
 
   c.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
   c.hashmap['long-array'] = new Array(20).fill(5);

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -126,9 +126,9 @@ tape('v8 inspect', (t) => {
     ext = extMatch[1];
 
     const extSlicedMatch = lines.match(
-      /.sliced-externalized-string=(0x[0-9a-f]+):<String: "\(external\)">/);
+        /.sliced-externalized-string=(0x[0-9a-f]+):<String: "\(external\)">/);
     t.ok(extSlicedMatch,
-      '.sliced-externalized-string Sliced ExternalString property');
+         '.sliced-externalized-string Sliced ExternalString property');
     extSliced = extSlicedMatch[1];
 
     sess.send(`v8 inspect ${regexp}`);

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -48,6 +48,8 @@ tape('v8 inspect', (t) => {
   let regexp = null;
   let cons = null;
   let thin = null;
+  let ext = null;
+  let extSliced = null;
   let arrowFunc = null;
   let array = null;
   let longArray = null;
@@ -78,12 +80,12 @@ tape('v8 inspect', (t) => {
     t.ok(/.other-key=[^\n]*<String: "ohai">/.test(lines),
          '.other-key property');
 
-    const arrayMatch = 
+    const arrayMatch =
         lines.match(/.array=(0x[0-9a-f]+):<Array: length=6>/);
     t.ok(arrayMatch, '.array JSArray property');
     array = arrayMatch[1];
 
-    const longArrayMatch = 
+    const longArrayMatch =
         lines.match(/.long-array=(0x[0-9a-f]+):<Array: length=20>/);
     t.ok(longArrayMatch, '.array JSArray property');
     longArray = longArrayMatch[1];
@@ -117,6 +119,17 @@ tape('v8 inspect', (t) => {
         /.thin-string=(0x[0-9a-f]+):<String: "foobar">/);
     t.ok(thinMatch, '.thin-string ThinString property');
     thin = thinMatch[1];
+
+    const extMatch = lines.match(
+        /.externalized-string=(0x[0-9a-f]+):<String: "\(external\)">/);
+    t.ok(extMatch, '.externalized-string ExternalString property');
+    ext = extMatch[1];
+
+    const extSlicedMatch = lines.match(
+      /.sliced-externalized-string=(0x[0-9a-f]+):<String: "\(external\)">/);
+    t.ok(extSlicedMatch,
+      '.sliced-externalized-string Sliced ExternalString property');
+    extSliced = extSlicedMatch[1];
 
     sess.send(`v8 inspect ${regexp}`);
     sess.send(`v8 inspect -F ${cons}`);


### PR DESCRIPTION
Sliced strings with an external string as a parent would use their offset and length values against the string "(external)" as support for external strings is not implemented yet.

This may resolve issue #112 as I see a crash in the same way without this fix however a crash in the inspect code for another type would manifest in the same way. I will ask @gentlejo to check if this resolves the problem for them.