### PR TITLE
llnode.cc: Combine array-length and string-length arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ v8 bt command. See the [Commands](#commands) section below for more commands.
 ### Commands
 
 ```
-(lldb) v8 help
+(llnode) v8 help
      Node.js helpers
 
 Syntax: v8
@@ -226,7 +226,7 @@ The following subcommands are supported:
                          Syntax: v8 bt [number]
       findjsinstances -- List all objects which share the specified map.
                          Accepts the same options as `v8 inspect`
-      findjsobjects   -- List all object types and instance counts grouped by map and sorted by instance count.
+      findjsobjects   -- List all object types and instance counts grouped by typename and sorted by instance count.
                          Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the
                          core file being debugged.
                          There are scripts for generating this file on Linux and Mac in the scripts directory of the llnode
@@ -238,7 +238,6 @@ The following subcommands are supported:
                           * -v, --value expr     - all properties that refer to the specified JavaScript object (default)
                           * -n, --name  name     - all properties with the specified name
                           * -s, --string string  - all properties that refer to the specified JavaScript string value
-                          * --array-length num   - print maximum of `num` elements in array
 
       inspect         -- Print detailed description and contents of the JavaScript value.
 
@@ -247,7 +246,7 @@ The following subcommands are supported:
                           * -F, --full-string    - print whole string without adding ellipsis
                           * -m, --print-map      - print object's map address
                           * -s, --print-source   - print source code for function objects
-                          * --string-length num  - print maximum of `num` characters in string
+                          * -l num, --length num - print maximum of `num` elements from string/array
 
                          Syntax: v8 inspect [flags] expr
       nodeinfo        -- Print information about Node.js

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -33,8 +33,9 @@ char** CommandBase::ParseInspectOptions(char** cmd,
                                         v8::Value::InspectOptions* options) {
   static struct option opts[] = {
       {"full-string", no_argument, nullptr, 'F'},
-      {"string-length", required_argument, nullptr, 0x1001},
-      {"array-length", required_argument, nullptr, 0x1002},
+      {"string-length", required_argument, nullptr, 'l'},
+      {"array-length", required_argument, nullptr, 'l'},
+      {"length", required_argument, nullptr, 'l'},
       {"print-map", no_argument, nullptr, 'm'},
       {"print-source", no_argument, nullptr, 's'},
       {nullptr, 0, nullptr, 0}};
@@ -54,21 +55,18 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, args, "Fms", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fmsl:", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
       case 'F':
-        options->string_length = 0;
+        options->length = 0;
         break;
       case 'm':
         options->print_map = true;
         break;
-      case 0x1001:
-        options->string_length = strtol(optarg, nullptr, 10);
-        break;
-      case 0x1002:
-        options->array_length = strtol(optarg, nullptr, 10);
+      case 'l':
+        options->length = strtol(optarg, nullptr, 10);
         break;
       case 's':
         options->print_source = true;
@@ -136,7 +134,8 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
       lldb::SBMemoryRegionInfo info;
       if (target.GetProcess().GetMemoryRegionInfo(pc, info).Success() &&
           info.IsExecutable() && info.IsWritable()) {
-        result.Printf("  %c frame #%u: 0x%016" PRIx64 " <builtin>\n", star, i, pc);
+        result.Printf("  %c frame #%u: 0x%016" PRIx64 " <builtin>\n", star, i,
+                      pc);
         continue;
       }
     }
@@ -326,8 +325,8 @@ bool PluginInitialize(SBDebugger d) {
       " * -F, --full-string    - print whole string without adding ellipsis\n"
       " * -m, --print-map      - print object's map address\n"
       " * -s, --print-source   - print source code for function objects\n"
-      " * --string-length num  - print maximum of `num` characters in string\n"
-      " * --array-length num   - print maximum of `num` elements in array\n"
+      " * -l num, --length num - print maximum of `num` elements from "
+      "string/array\n"
       "\n"
       "Syntax: v8 inspect [flags] expr\n");
   interpreter.AddCommand("jsprint", new llnode::PrintCmd(true),
@@ -342,8 +341,8 @@ bool PluginInitialize(SBDebugger d) {
                          "Alias for `v8 source list`");
 
   v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
-                "List all object types and instance counts grouped by map and "
-                "sorted by instance count.\n"
+                "List all object types and instance counts grouped by type"
+                "name and sorted by instance count.\n"
 #ifndef LLDB_SBMemoryRegionInfoList_h_
                 "Requires `LLNODE_RANGESFILE` environment variable to be set "
                 "to a file containing memory ranges for the core file being "

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -966,7 +966,7 @@ std::string String::Inspect(InspectOptions* options, Error& err) {
   std::string val = ToString(err);
   if (err.Fail()) return std::string();
 
-  unsigned int len = options->string_length;
+  unsigned int len = options->length;
 
   if (len != 0 && val.length() > len) val = val.substr(0, len) + "...";
 
@@ -1119,7 +1119,7 @@ std::string JSArrayBuffer::Inspect(InspectOptions* options, Error& err) {
   if (options->detailed) {
     res += ": [\n  ";
 
-    int display_length = std::min<int>(byte_length, options->array_length);
+    int display_length = std::min<int>(byte_length, options->length);
     res += v8()->LoadBytes(display_length, data, err);
 
     if (display_length < byte_length) {
@@ -1164,7 +1164,7 @@ std::string JSArrayBufferView::Inspect(InspectOptions* options, Error& err) {
   if (options->detailed) {
     res += ": [\n  ";
 
-    int display_length = std::min<int>(byte_length, options->array_length);
+    int display_length = std::min<int>(byte_length, options->length);
     res += v8()->LoadBytes(display_length, data + byte_offset, err);
 
     if (display_length < byte_length) {
@@ -1914,7 +1914,7 @@ std::string JSArray::Inspect(InspectOptions* options, Error& err) {
 
   std::string res = "<Array: length=" + std::to_string(length);
   if (options->detailed) {
-    int64_t display_length = std::min<int64_t>(length, options->array_length);
+    int64_t display_length = std::min<int64_t>(length, options->length);
     std::string elems = InspectElements(display_length, err);
     if (err.Fail()) return std::string();
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -51,17 +51,14 @@ class Value {
         : detailed(false),
           print_map(false),
           print_source(false),
-          string_length(kStringLength),
-          array_length(kArrayLength) {}
+          length(kLength) {}
 
-    static const unsigned int kStringLength = 16;
-    static const unsigned int kArrayLength = 16;
+    static const unsigned int kLength = 16;
 
     bool detailed;
     bool print_map;
     bool print_source;
-    unsigned int string_length;
-    unsigned int array_length;
+    unsigned int length;
   };
 
   Value(const Value& v) = default;


### PR DESCRIPTION
When I reviewed PR #116 for @joyeecheung I noticed that we have separate length arguments to v8 inspect for Strings and Arrays when we can only be inspecting one or the other. This PR merges the two into `--length` as they can never both apply at the same time. It also supports a short option, `-l`, to the user quickly specify how many elements of either strings or arrays to display. The major usability improvement is that you can just specify `-l` instead of having to type out `--array-length` or `--string-length`.

I did consider using `--count` and `-c` instead and I'm happy to swap around if anyone thinks that's better.