### PR TITLE
llscan.cc: Add findjsinstances --verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ make -C out/ -j9
 sudo make install-linux
 ```
 
+### FreeBSD
+
+```bash
+# Clone this repo
+git clone https://github.com/nodejs/llnode.git && cd llnode
+
+# Install llvm with lldb and headers
+pkg install llvm39
+rm -f /usr/bin/lldb
+ln -s /usr/local/bin/lldb39 /usr/bin/lldb
+
+# Initialize GYP
+git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
+
+# Configure
+./gyp_llnode -Dlldb_dir=/usr/local/llvm39/
+
+# Build
+gmake -C out/ -j9
+```
+
+(The LLDB function ComputeSystemPluginsDirectory is not implemented on FreeBSD.
+The plugin library must be loaded manually.)
+
+
 ## Loading the lldb plugin library.
 
 The simplest method is:
@@ -144,6 +169,15 @@ To install the plugin in the LLDB system plugin directory, use the
 `make install-linux` build step above, or if installing with
 npm copy `node_modules/llnode/llnode.so` to
 `/usr/lib/lldb/plugins`.
+
+### FreeBSD
+
+```
+lldb
+
+(lldb) plugin load ./node_modules/llnode/llnode.so
+```
+LLDB does not support the system plugin directory on FreeBSD.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The following subcommands are supported:
 
                          Syntax: v8 bt [number]
       findjsinstances -- List every object with the specified type name.
-                         Use -i or --inspect to display detailed `v8 inspect` outputfor each object.
+                         Use -i or --inspect to display detailed `v8 inspect` output for each object.
                          Accepts the same options as `v8 inspect`
       findjsobjects   -- List all object types and instance counts grouped by map and sorted by instance count.
                          Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ The following subcommands are supported:
                          dumped.
 
                          Syntax: v8 bt [number]
-      findjsinstances -- List all objects which share the specified map.
+      findjsinstances -- List every object with the specified type name.
+                         Use -i or --inspect to display detailed `v8 inspect` outputfor each object.
                          Accepts the same options as `v8 inspect`
       findjsobjects   -- List all object types and instance counts grouped by map and sorted by instance count.
                          Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The following subcommands are supported:
 
                          Syntax: v8 bt [number]
       findjsinstances -- List every object with the specified type name.
-                         Use -i or --inspect to display detailed `v8 inspect` output for each object.
+                         Use -v or --verbose to display detailed `v8 inspect` output for each object.
                          Accepts the same options as `v8 inspect`
       findjsobjects   -- List all object types and instance counts grouped by typename and sorted by instance count.
                          Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llnode",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Node.js plugin for LLDB",
   "main": "no-entry-sorry.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "//": "(Blame C++)",
   "scripts": {
     "preinstall": "node scripts/configure.js",
-    "install": "./gyp_llnode && make -C out/",
+    "install": "./gyp_llnode && ( gmake -C out/ || make -C out/ )",
     "postinstall": "node scripts/cleanup.js",
     "test": "tape test/*-test.js"
   },

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -38,7 +38,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       {"length", required_argument, nullptr, 'l'},
       {"print-map", no_argument, nullptr, 'm'},
       {"print-source", no_argument, nullptr, 's'},
-      {"inspect", no_argument, nullptr, 'i'},
+      {"verbose", no_argument, nullptr, 'v'},
       {nullptr, 0, nullptr, 0}};
 
   int argc = 1;
@@ -56,7 +56,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, args, "Fmsil:", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fmsvl:", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
@@ -72,7 +72,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       case 's':
         options->print_source = true;
         break;
-      case 'i':
+      case 'v':
         options->detailed = true;
         break;
       default:
@@ -361,7 +361,7 @@ bool PluginInitialize(SBDebugger d) {
 
   v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                 "List every object with the specified type name.\n"
-                "Use -i or --inspect to display detailed `v8 inspect` output "
+                "Use -v or --verbose to display detailed `v8 inspect` output "
                 "for each object.\n"
                 "Accepts the same options as `v8 inspect`");
 

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -357,7 +357,9 @@ bool PluginInitialize(SBDebugger d) {
                          "Alias for `v8 findjsobjects`");
 
   v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
-                "List all objects which share the specified map.\n"
+                "List every object with the specified type name.\n"
+                "Use -i or --inspect to display detailed `v8 inspect` output"
+                "for each object.\n"
                 "Accepts the same options as `v8 inspect`");
 
   interpreter.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -358,7 +358,7 @@ bool PluginInitialize(SBDebugger d) {
 
   v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                 "List every object with the specified type name.\n"
-                "Use -i or --inspect to display detailed `v8 inspect` output"
+                "Use -i or --inspect to display detailed `v8 inspect` output "
                 "for each object.\n"
                 "Accepts the same options as `v8 inspect`");
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -101,20 +101,7 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
 
   inspect_options.detailed = detailed_;
 
-  char** start = cmd;
-  for (; cmd != nullptr && *start != nullptr; start++) {
-    if (strcmp(*start, "-i") == 0 || strcmp(*start, "--inspect") == 0) {
-      inspect_options.detailed = true;
-      // Shuffle up the remaining parameters.
-      char** curr = start;
-      for (; *curr != nullptr; curr++) {
-        char** next = curr + 1;
-        *curr = *next;
-      }
-    }
-  }
-
-  start = ParseInspectOptions(cmd, &inspect_options);
+  char** start = ParseInspectOptions(cmd, &inspect_options);
 
   std::string full_cmd;
   for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -81,7 +81,7 @@ bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
 bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
                                  SBCommandReturnObject& result) {
   if (cmd == nullptr || *cmd == nullptr) {
-    result.SetError("USAGE: v8 findjsinstances [-Fm] instance_name\n");
+    result.SetError("USAGE: v8 findjsinstances [flags] instance_name\n");
     return false;
   }
 
@@ -101,7 +101,20 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
 
   inspect_options.detailed = detailed_;
 
-  char** start = ParseInspectOptions(cmd, &inspect_options);
+  char** start = cmd;
+  for (; cmd != nullptr && *start != nullptr; start++) {
+    if (strcmp(*start, "-i") == 0 || strcmp(*start, "--inspect") == 0) {
+      inspect_options.detailed = true;
+      // Shuffle up the remaining parameters.
+      char** curr = start;
+      for (; *curr != nullptr; curr++) {
+        char** next = curr + 1;
+        *curr = *next;
+      }
+    }
+  }
+
+  start = ParseInspectOptions(cmd, &inspect_options);
 
   std::string full_cmd;
   for (; start != nullptr && *start != nullptr; start++) full_cmd += *start;


### PR DESCRIPTION
This adds a `--inspect`, `-i` option to findjsinstances so that the output of `v8 inspect` is displayed for each instance of a type instead of `v8 print` output. This makes it quicker to view the contents of objects especially where there are few instances of the same kind.

If there's only one instance of `MyObject` then it's easier to type:
```
(llnode) v8 findjsinstances -i MyObject
```
than
```
(llnode) v8 findjsinstances MyObject
0x00002d2fae211241:<Object: MyObject>
(llnode) v8 inspect 0x00002d2fae211241
```
if there's a small number then it's much easier than cut and pasting each hexadecimal reference in turn.

I chose `--inspect` as that matches `v8 inspect` however it could also be `--verbose` and `-v`.