### PR TITLE
src,test: support V8 6.1 postmortem data

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -350,7 +350,7 @@ bool PluginInitialize(SBDebugger d) {
                 "There are scripts for generating this file on Linux and Mac "
                 "in the scripts directory of the llnode repository."
 #endif  // LLDB_SBMemoryRegionInfoList_h_
-                );
+  );
 
   interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
                          "Alias for `v8 findjsobjects`");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -471,7 +471,6 @@ void DescriptorArray::Load() {
         LoadConstant("prop_attributes_DONT_ENUM");
 
     kPropertyKindMask = LoadConstant("prop_kind_mask");
-    kPropertyKindShift = LoadConstant("prop_kind_shift", int64_t(0));
     kPropertyKindEnum_kAccessor = LoadConstant("prop_kind_Accessor");
     kPropertyKindEnum_kData = LoadConstant("prop_kind_Data");
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -212,8 +212,13 @@ void Map::Load() {
 
 
 void JSObject::Load() {
-  kPropertiesOffset = LoadConstant("class_JSReceiver__properties__FixedArray",
-                                   "class_JSObject__properties__FixedArray");
+  kPropertiesOffset =
+      LoadConstant("class_JSReceiver__raw_properties_or_hash__Object",
+                   "class_JSReceiver__properties__FixedArray");
+
+  if (kPropertiesOffset == -1)
+    kPropertiesOffset = LoadConstant("class_JSObject__properties__FixedArray");
+
   kElementsOffset = LoadConstant("class_JSObject__elements__Object");
   kInternalFieldsOffset =
       LoadConstant("class_JSObject__internal_fields__uintptr_t");
@@ -262,19 +267,27 @@ void JSDate::Load() {
 
 
 void SharedInfo::Load() {
-  kNameOffset = LoadConstant("class_SharedFunctionInfo__name__Object");
+  kNameOffset = LoadConstant("class_SharedFunctionInfo__raw_name__Object",
+                             "class_SharedFunctionInfo__name__Object");
   kInferredNameOffset =
       LoadConstant("class_SharedFunctionInfo__inferred_name__String",
                    "class_SharedFunctionInfo__function_identifier__Object");
   kScriptOffset = LoadConstant("class_SharedFunctionInfo__script__Object");
   kCodeOffset = LoadConstant("class_SharedFunctionInfo__code__Code");
   kStartPositionOffset =
-      LoadConstant("class_SharedFunctionInfo__start_position_and_type__SMI");
+      LoadConstant("class_SharedFunctionInfo__start_position_and_type__int",
+                   "class_SharedFunctionInfo__start_position_and_type__SMI");
   kEndPositionOffset =
-      LoadConstant("class_SharedFunctionInfo__end_position__SMI");
+      LoadConstant("class_SharedFunctionInfo__end_position__int",
+                   "class_SharedFunctionInfo__end_position__SMI");
   kParameterCountOffset = LoadConstant(
-      "class_SharedFunctionInfo__internal_formal_parameter_count__SMI",
-      "class_SharedFunctionInfo__formal_parameter_count__SMI");
+      "class_SharedFunctionInfo__internal_formal_parameter_count__int",
+      "class_SharedFunctionInfo__internal_formal_parameter_count__SMI");
+
+  if (kParameterCountOffset == -1) {
+    kParameterCountOffset =
+        LoadConstant("class_SharedFunctionInfo__formal_parameter_count__SMI");
+  }
 
   // NOTE: Could potentially be -1 on v4 and v5 node, should check in llv8
   kScopeInfoOffset =
@@ -288,6 +301,11 @@ void SharedInfo::Load() {
     kStartPositionShift = 2;
     kStartPositionMask = ~((1 << kStartPositionShift) - 1);
   }
+
+  if (LoadConstant("class_SharedFunctionInfo__compiler_hints__int") == -1)
+    kEndPositionShift = 1;
+  else
+    kEndPositionShift = 0;
 }
 
 
@@ -301,7 +319,6 @@ void ScopeInfo::Load() {
   kParameterCountOffset = LoadConstant("scopeinfo_idx_nparams");
   kStackLocalCountOffset = LoadConstant("scopeinfo_idx_nstacklocals");
   kContextLocalCountOffset = LoadConstant("scopeinfo_idx_ncontextlocals");
-  kContextGlobalCountOffset = LoadConstant("scopeinfo_idx_ncontextglobals");
   kVariablePartIndex = LoadConstant("scopeinfo_idx_first_vars");
 }
 
@@ -374,6 +391,14 @@ void FixedArrayBase::Load() {
 
 void FixedArray::Load() {
   kDataOffset = LoadConstant("class_FixedArray__data__uintptr_t");
+}
+
+
+void FixedTypedArrayBase::Load() {
+  kBasePointerOffset =
+      LoadConstant("class_FixedTypedArrayBase__base_pointer__Object");
+  kExternalPointerOffset =
+      LoadConstant("class_FixedTypedArrayBase__external_pointer__Object");
 }
 
 
@@ -516,7 +541,8 @@ void Frame::Load() {
 
   kAdaptorFrame = LoadConstant("frametype_ArgumentsAdaptorFrame");
   kEntryFrame = LoadConstant("frametype_EntryFrame");
-  kEntryConstructFrame = LoadConstant("frametype_EntryConstructFrame");
+  kEntryConstructFrame = LoadConstant("frametype_ConstructEntryFrame",
+                                      "frametype_EntryConstructFrame");
   kExitFrame = LoadConstant("frametype_ExitFrame");
   kInternalFrame = LoadConstant("frametype_InternalFrame");
   kConstructFrame = LoadConstant("frametype_ConstructFrame");
@@ -537,7 +563,8 @@ void Types::Load() {
   kOddballType = LoadConstant("type_Oddball__ODDBALL_TYPE");
   kJSObjectType = LoadConstant("type_JSObject__JS_OBJECT_TYPE");
   kJSAPIObjectType = LoadConstant("APIObjectType");
-  kJSSpecialAPIObjectType = LoadConstant("APISpecialObjectType");
+  kJSSpecialAPIObjectType =
+      LoadConstant("SpecialAPIObjectType", "APISpecialObjectType");
   kJSArrayType = LoadConstant("type_JSArray__JS_ARRAY_TYPE");
   kCodeType = LoadConstant("type_Code__CODE_TYPE");
   kJSFunctionType = LoadConstant("type_JSFunction__JS_FUNCTION_TYPE");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -418,7 +418,6 @@ class DescriptorArray : public Module {
   int64_t kPropertyAttributesEnum_DONT_DELETE = -1;
 
   int64_t kPropertyKindMask = -1;
-  int64_t kPropertyKindShift = -1;
   int64_t kPropertyKindEnum_kAccessor = -1;
   int64_t kPropertyKindEnum_kData = -1;
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -176,6 +176,7 @@ class SharedInfo : public Module {
 
   int64_t kStartPositionMask;
   int64_t kStartPositionShift;
+  int64_t kEndPositionShift;
 
  protected:
   void Load();
@@ -199,7 +200,6 @@ class ScopeInfo : public Module {
   int64_t kParameterCountOffset;
   int64_t kStackLocalCountOffset;
   int64_t kContextLocalCountOffset;
-  int64_t kContextGlobalCountOffset;
   int64_t kVariablePartIndex;
 
  protected:
@@ -323,6 +323,17 @@ class FixedArray : public Module {
   MODULE_DEFAULT_METHODS(FixedArray);
 
   int64_t kDataOffset;
+
+ protected:
+  void Load();
+};
+
+class FixedTypedArrayBase : public Module {
+ public:
+  MODULE_DEFAULT_METHODS(FixedTypedArrayBase);
+
+  int64_t kBasePointerOffset;
+  int64_t kExternalPointerOffset;
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -259,7 +259,8 @@ inline int64_t SharedFunctionInfo::EndPosition(Error& err) {
   if (err.Fail()) return -1;
 
   field &= 0xffffffff;
-  return field >> 1;
+  field >>= v8()->shared_info()->kEndPositionShift;
+  return field;
 }
 
 ACCESSOR(JSFunction, Info, js_function()->kSharedInfoOffset,
@@ -275,6 +276,14 @@ ACCESSOR(SlicedString, Offset, sliced_string()->kOffsetOffset, Smi);
 ACCESSOR(ThinString, Actual, thin_string()->kActualOffset, String);
 
 ACCESSOR(FixedArrayBase, Length, fixed_array_base()->kLengthOffset, Smi);
+
+inline int64_t FixedTypedArrayBase::GetBase(Error& err) {
+  return LoadField(v8()->fixed_typed_array_base()->kBasePointerOffset, err);
+}
+
+inline int64_t FixedTypedArrayBase::GetExternal(Error& err) {
+  return LoadField(v8()->fixed_typed_array_base()->kExternalPointerOffset, err);
+}
 
 inline std::string OneByteString::ToString(Error& err) {
   int64_t chars = LeaField(v8()->one_byte_string()->kCharsOffset);
@@ -449,11 +458,6 @@ inline Smi ScopeInfo::StackLocalCount(Error& err) {
 
 inline Smi ScopeInfo::ContextLocalCount(Error& err) {
   return FixedArray::Get<Smi>(v8()->scope_info()->kContextLocalCountOffset,
-                              err);
-}
-
-inline Smi ScopeInfo::ContextGlobalCount(Error& err) {
-  return FixedArray::Get<Smi>(v8()->scope_info()->kContextGlobalCountOffset,
                               err);
 }
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -45,6 +45,7 @@ void LLV8::Load(SBTarget target) {
   thin_string.Assign(target, &common);
   fixed_array_base.Assign(target, &common);
   fixed_array.Assign(target, &common);
+  fixed_typed_array_base.Assign(target, &common);
   oddball.Assign(target, &common);
   js_array_buffer.Assign(target, &common);
   js_array_buffer_view.Assign(target, &common);
@@ -1151,6 +1152,18 @@ std::string JSArrayBufferView::Inspect(InspectOptions* options, Error& err) {
 
   int64_t data = buf.BackingStore(err);
   if (err.Fail()) return std::string();
+
+  if (data == 0) {
+    // The backing store has not been materialized yet.
+    HeapObject elements_obj = Elements(err);
+    if (err.Fail()) return std::string();
+    FixedTypedArrayBase elements(elements_obj);
+    int64_t base = elements.GetBase(err);
+    if (err.Fail()) return std::string();
+    int64_t external = elements.GetExternal(err);
+    if (err.Fail()) return std::string();
+    data = base + external;
+  }
 
   Smi off = ByteOffset(err);
   if (err.Fail()) return std::string();

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -340,6 +340,14 @@ class FixedArray : public FixedArrayBase {
   std::string InspectContents(int length, Error& err);
 };
 
+class FixedTypedArrayBase : public FixedArrayBase {
+ public:
+  V8_VALUE_DEFAULT_METHODS(FixedTypedArrayBase, FixedArrayBase)
+
+  inline int64_t GetBase(Error& err);
+  inline int64_t GetExternal(Error& err);
+};
+
 class DescriptorArray : public FixedArray {
  public:
   V8_VALUE_DEFAULT_METHODS(DescriptorArray, FixedArray)
@@ -383,7 +391,6 @@ class ScopeInfo : public FixedArray {
   inline Smi ParameterCount(Error& err);
   inline Smi StackLocalCount(Error& err);
   inline Smi ContextLocalCount(Error& err);
-  inline Smi ContextGlobalCount(Error& err);
 
   inline String ContextLocalName(int index, int param_count, int stack_count,
                                  Error& err);
@@ -400,9 +407,9 @@ class Oddball : public HeapObject {
   std::string Inspect(Error& err);
 };
 
-class JSArrayBuffer : public HeapObject {
+class JSArrayBuffer : public JSObject {
  public:
-  V8_VALUE_DEFAULT_METHODS(JSArrayBuffer, HeapObject)
+  V8_VALUE_DEFAULT_METHODS(JSArrayBuffer, JSObject)
 
   inline int64_t BackingStore(Error& err);
   inline int64_t BitField(Error& err);
@@ -413,9 +420,9 @@ class JSArrayBuffer : public HeapObject {
   std::string Inspect(InspectOptions* options, Error& err);
 };
 
-class JSArrayBufferView : public HeapObject {
+class JSArrayBufferView : public JSObject {
  public:
-  V8_VALUE_DEFAULT_METHODS(JSArrayBufferView, HeapObject)
+  V8_VALUE_DEFAULT_METHODS(JSArrayBufferView, JSObject)
 
   inline JSArrayBuffer Buffer(Error& err);
   inline Smi ByteOffset(Error& err);
@@ -484,6 +491,7 @@ class LLV8 {
   constants::SlicedString sliced_string;
   constants::ThinString thin_string;
   constants::FixedArrayBase fixed_array_base;
+  constants::FixedTypedArrayBase fixed_typed_array_base;
   constants::FixedArray fixed_array;
   constants::Oddball oddball;
   constants::JSArrayBuffer js_array_buffer;
@@ -515,6 +523,7 @@ class LLV8 {
   friend class JSArray;
   friend class FixedArrayBase;
   friend class FixedArray;
+  friend class FixedTypedArrayBase;
   friend class DescriptorArray;
   friend class NameDictionary;
   friend class Context;

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -78,12 +78,12 @@ tape('v8 inspect', (t) => {
     t.ok(/.other-key=[^\n]*<String: "ohai">/.test(lines),
          '.other-key property');
 
-    const arrayMatch = 
+    const arrayMatch =
         lines.match(/.array=(0x[0-9a-f]+):<Array: length=6>/);
     t.ok(arrayMatch, '.array JSArray property');
     array = arrayMatch[1];
 
-    const longArrayMatch = 
+    const longArrayMatch =
         lines.match(/.long-array=(0x[0-9a-f]+):<Array: length=20>/);
     t.ok(longArrayMatch, '.array JSArray property');
     longArray = longArrayMatch[1];


### PR DESCRIPTION
This is still a work in progress, but adds postmortem debugging support for V8 6.1. The following issues still need to be resolved (all marked with `TODO` in the code):

- [x] ~~Properly handle the end offset of function bodies. It previously needed to be shifted, but that is no longer the case. This just needs version detection logic.~~
- [x] ~~Properly load the `ThinStringTag` constant. `V8DBG_THINSTRINGTAG` appears to be defined, but the constant isn't loading. Right now, the value of `0x5` is hard coded.~~
- [x] ~~Support `Uint8Array`s. Those tests are currently broken and commented out. The problem is that the backing store of the `JSArrayBufferView`'s `JSArrayBuffer` is coming back as all zeros.~~

UPDATE: The issue with the `Uint8Array`s is that the backing stores are not materialized. If the test is updated to reference the `.buffer` property, the backing store is materialized and shows up properly in llnode.