### PR TITLE
configure.js: Simplify lldb version handling

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -131,7 +131,7 @@ fs.writeFileSync(`${buildDir}/scripts/llnode.sh`, scriptText(lldbExe));
 process.exit(0);
 
 function lldbVersionToBranch(version) {
-    return 'release_' + version.replace('.','');
+  return 'release_' + version.replace('.', '');
 }
 
 // On Mac the lldb version string doesn't match the original lldb versions.
@@ -202,7 +202,7 @@ function getLinuxVersion(lldbExe) {
   // Ignore minor revisions like 3.8.1
   let versionMatch = lldbStr.match(/version (\d.\d)/);
   if (versionMatch) {
-      return versionMatch[1];
+    return versionMatch[1];
   }
   return undefined;
 }


### PR DESCRIPTION
This change removes the hardcoded map of lldb versions to release branches. This makes it easier to use the --lldb_exe= parameter to handle unknown releases should find the correct branch for pre-release lldb builds or local builds of lldb.
It also makes the the installer aware of lldb-5.0 binaries on Linux since pre-release versions can be installed directly from llvm.org, see: http://apt.llvm.org/

This fixes issue #133 