### PR TITLE
Fix for printing source

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -212,7 +212,7 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
 
 bool ListCmd::DoExecute(SBDebugger d, char** cmd,
                         SBCommandReturnObject& result) {
-  if (cmd == nullptr || *cmd == nullptr) {
+  if (cmd == nullptr) {
     result.SetError("USAGE: v8 source list\n");
     return false;
   }


### PR DESCRIPTION
This update fixes https://github.com/nodejs/llnode/issues/138 
Tested on Ubuntu 16.04 and FreeBSD 12 
As per the feedback `jssource` has been tested and also works 