### PR TITLE
doc: update LLNODE_RANGESFILE documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ The following subcommands are supported:
                          Use -v or --verbose to display detailed `v8 inspect` output for each object.
                          Accepts the same options as `v8 inspect`
       findjsobjects   -- List all object types and instance counts grouped by typename and sorted by instance count.
-                         Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the
-                         core file being debugged.
+                         With lldb < 3.9, requires the `LLNODE_RANGESFILE` environment variable to be set to a file
+                         containing memory ranges for the core file being debugged.
                          There are scripts for generating this file on Linux and Mac in the scripts directory of the llnode
                          repository.
       findrefs        -- Finds all the object properties which meet the search criteria.


### PR DESCRIPTION
Document that the LLNODE_RANGESFILE environment variable is not needed
with lldb >= 3.9.