### PR TITLE
Try to use the version from llvm-config on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 out/
 npm-debug.log
 node_modules/
+options.gypi

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -28,7 +28,7 @@ if (osName === 'Darwin') {
   }
 
   console.log(`Installing llnode for ${lldbExe}, lldb version ${lldbVersion}`);
-  const installedDir = getDarwinIntallDir();
+  const installedDir = getDarwinInstallDir();
   if (installedDir === undefined) {
     const lldbHeadersBranch = lldbVersionToBranch(lldbVersion);
     lldbInstallDir = 'lldb-' + lldbVersion;
@@ -90,8 +90,7 @@ function getLldbHeadersPath(lldbInstallDir) {
 // should stop using the mirror.
 function cloneHeaders(lldbHeadersBranch, lldbInstallDir, buildDir) {
   const lldbHeaders = getLldbHeadersPath(lldbInstallDir);
-  if (!fs.existsSync(lldbHeaders)) {
-    child_process.execSync(`rm -rf ${lldbInstallDir}`);
+  if (!fs.existsSync(lldbInstallDir)) {
     console.log(`Cloning lldb from ${lldbHeadersBranch} to ${lldbInstallDir}`);
     child_process.execFileSync('git',
       ['clone', '--depth=1', '-b', lldbHeadersBranch,
@@ -174,7 +173,7 @@ function getDarwinRelease() {
   var versionStr = '';
   var splitStr = xcodeStr.split(os.EOL);
   for (var str of splitStr) {
-    if (str.indexOf('Xcode') !== -1) {
+    if (str.includes('Xcode')) {
       versionStr = str.split(' ')[1];
       break;
     }
@@ -203,7 +202,7 @@ function setDarwinBuildDir() {
   console.log(options);
 }
 
-function getDarwinIntallDir() {
+function getDarwinInstallDir() {
   var installedDir;
   try {
     installedDir = child_process.execFileSync('llvm-config', [

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -11,9 +11,8 @@ console.log('Build dir is: ' + buildDir);
 
 const osName = os.type();
 
-var lldbVersion;
-var lldbHeadersBranch;
-var lldbIncludeDir;
+var lldbVersion; // Similar to what `llvm-config --version` returns
+var lldbInstallDir;  // Where the lldb installation is, `llvm-config --prefix`
 
 // Need to determine:
 // - What level of lldb we are running.
@@ -21,7 +20,6 @@ var lldbIncludeDir;
 var lldbExe = 'lldb';
 
 if (osName === 'Darwin') {
-
   lldbVersion = getDarwinRelease();
 
   if (lldbVersion === undefined) {
@@ -29,11 +27,18 @@ if (osName === 'Darwin') {
     process.exit(1);
   }
 
-  lldbHeadersBranch = lldbVersionToBranch(lldbVersion);
-  lldbIncludeDir = 'lldb-' + lldbVersion;
-
+  console.log(`Installing llnode for ${lldbExe}, lldb version ${lldbVersion}`);
+  const installedDir = getDarwinIntallDir();
+  if (installedDir === undefined) {
+    const lldbHeadersBranch = lldbVersionToBranch(lldbVersion);
+    lldbInstallDir = 'lldb-' + lldbVersion;
+    cloneHeaders(lldbHeadersBranch, lldbInstallDir, buildDir);
+    fs.writeFileSync('options.gypi', '{}', 'utf-8');
+  } else {
+    lldbInstallDir = installedDir;
+    setDarwinBuildDir();
+  }
 } else if (osName === 'Linux') {
-
   lldbExe = getLldbExecutable();
   lldbVersion = getLinuxVersion(lldbExe);
 
@@ -42,18 +47,17 @@ if (osName === 'Darwin') {
     process.exit(1);
   }
 
-  // console.log('lldb_version is ' + lldb_version)
-  const installedHeadersDir = getLinuxHeadersDir(lldbVersion);
-  // console.log('installed_headers_dir is ' + installed_headers_dir);
-  if (installedHeadersDir === undefined) {
-    // Initialising lldb_headers_branch will cause us to clone them.
-    lldbHeadersBranch = lldbVersionToBranch(lldbVersion);
-    lldbIncludeDir = 'lldb-' + lldbVersion;
+  console.log(`Installing llnode for ${lldbExe}, lldb version ${lldbVersion}`);
+  const installedDir = getLinuxInstallDir(lldbVersion);
+  if (installedDir === undefined) {
+    const lldbHeadersBranch = lldbVersionToBranch(lldbVersion);
+    lldbInstallDir = 'lldb-' + lldbVersion;
+    cloneHeaders(lldbHeadersBranch, lldbInstallDir, buildDir);
+    fs.writeFileSync('options.gypi', '{}', 'utf-8');
   } else {
-    lldbIncludeDir = installedHeadersDir;
+    lldbInstallDir = installedDir;
   }
 } else if (osName === 'FreeBSD') {
-
   lldbExe = getLldbExecutable();
   lldbVersion = getFreeBSDVersion(lldbExe);
 
@@ -62,8 +66,9 @@ if (osName === 'Darwin') {
     process.exit(1);
   }
 
-  const installedHeadersDir = getFreeBSDHeadersDir(lldbVersion);
-  if (installedHeadersDir === undefined) {
+  console.log(`Installing llnode for ${lldbExe}, lldb version ${lldbVersion}`);
+  const installedDir = getFreeBSDInstallDir(lldbVersion);
+  if (installedDir === undefined) {
     // As this is a BSD we know this system is in an improper state
     // So we can exit with an error
     console.log('The system isn\'t set up correcly.');
@@ -71,41 +76,44 @@ if (osName === 'Darwin') {
     console.log('And `ln -s /usr/local/bin/lldb39 /usr/bin/lldb`');
     process.exit(1);
   } else {
-    lldbIncludeDir = installedHeadersDir;
+    lldbInstallDir = installedDir;
   }
-
 }
 
-console.log(`Installing llnode for ${lldbExe}, lldb version ${lldbVersion}`);
+// This should be equivalent to `llvm-config --includedir`/lldb
+function getLldbHeadersPath(lldbInstallDir) {
+  return path.join(lldbInstallDir, 'include', 'lldb');
+}
 
-// Check out source code of the LLDB that is compatible with OS X's default lldb
+// Check out source code of the LLDB for headers
 // TODO: The llvm project is probably moving to github soon at that point we
 // should stop using the mirror.
-if (lldbHeadersBranch != undefined) {
-  if (!fs.lstatSync(path.join(lldbIncludeDir, 'include')).isDirectory()) {    
-    console.log('Cloning lldb from ' + lldbHeadersBranch);  
-    child_process.execSync(`rm -rf ${lldbIncludeDir}`);
+function cloneHeaders(lldbHeadersBranch, lldbInstallDir, buildDir) {
+  const lldbHeaders = getLldbHeadersPath(lldbInstallDir);
+  if (!fs.existsSync(lldbHeaders)) {
+    child_process.execSync(`rm -rf ${lldbInstallDir}`);
+    console.log(`Cloning lldb from ${lldbHeadersBranch} to ${lldbInstallDir}`);
     child_process.execFileSync('git',
-    ['clone', '--depth=1', '-b', lldbHeadersBranch,
-      'https://github.com/llvm-mirror/lldb.git', lldbIncludeDir],
-    {
-      cwd: buildDir,
-      stdio: 'inherit'  // show progress
-    });
+      ['clone', '--depth=1', '-b', lldbHeadersBranch,
+        'https://github.com/llvm-mirror/lldb.git', lldbInstallDir],
+      {
+        cwd: buildDir,
+        stdio: 'inherit'  // show progress
+      });
   } else {
-    console.log(`Skip cloning lldb headers because ${lldbIncludeDir} exists`);
+    console.log(`Skip cloning lldb headers because ${lldbHeaders} exists`);
   }
 }
 
 // Link to the headers file so we can run gyp_llnode directly and don't need to
 // setup parameters to pass it.
-console.log(`Linking lldb to include directory ${lldbIncludeDir}`);
+console.log(`Linking lldb to installation directory ${lldbInstallDir}`);
 try {
   fs.unlinkSync('lldb');
 } catch (error) {
   // File does not exist, no need to handle.
 }
-fs.symlinkSync(lldbIncludeDir, 'lldb');
+fs.symlinkSync(lldbInstallDir, 'lldb');
 
 // npm explore has a different root folder when using -g
 // So we are tacking on the extra the additional subfolders
@@ -114,10 +122,10 @@ if (process.env.npm_config_global) {
   gypSubDir = 'npm/node_modules/node-gyp';
 }
 
-// npm can be in a different location than the current                                                                                         
-// location for global installs so we need find out where the npm is                                                                              
-var npmLocation = child_process.execFileSync('which', ['npm']);                                                                                           
-var npmModules = path.join(npmLocation.toString(), '../../lib/node_modules/npm'); 
+// npm can be in a different location than the current
+// location for global installs so we need find out where the npm is
+var npmLocation = child_process.execFileSync('which', ['npm']);
+var npmModules = path.join(npmLocation.toString(), '../../lib/node_modules/npm');
 
 // Initialize GYP
 // We can use the node-gyp that comes with npm.
@@ -143,31 +151,30 @@ function lldbVersionToBranch(version) {
 
 // On Mac the lldb version string doesn't match the original lldb versions.
 function getDarwinRelease() {
+  var versionFromConfig;
   try {
-    const version = child_process.execFileSync('llvm-config', ['--version']).toString().trim();
-    const prefix = child_process.execFileSync('llvm-config', ['--prefix']).toString().trim();
-    const options = JSON.stringify({
-      variables: { "lldb_build_dir%": prefix }
-    }, null, 2);
-    fs.writeFileSync('options.gypi', Buffer.from(options), 'utf-8');
-    console.log('Overwriting options.gypi with output from llvm-config:');
-    console.log(options);
-    return version.split('.').slice(0, 2).join('.');
-  } catch(err) {
+    versionFromConfig = child_process.execFileSync('llvm-config', [
+      '--version'
+    ]).toString().trim();
+  } catch (err) {
     // No llvm-config, try to get the version from xcodebuild
+  }
+  if (versionFromConfig !== undefined) {
+    return versionFromConfig.split('.').slice(0, 2).join('.');
   }
 
   var xcodeStr;
   try {
-    xcodeStr = child_process.execFileSync('xcodebuild', ['-version'])
-    .toString();
+    xcodeStr = child_process.execFileSync('xcodebuild', [
+      '-version'
+    ]).toString();
   } catch (err) {
     return undefined;
   }
   var versionStr = '';
   var splitStr = xcodeStr.split(os.EOL);
   for (var str of splitStr) {
-    if (str.indexOf('Xcode') != -1) {
+    if (str.indexOf('Xcode') !== -1) {
       versionStr = str.split(' ')[1];
       break;
     }
@@ -184,6 +191,34 @@ function getDarwinRelease() {
   }
 }
 
+function setDarwinBuildDir() {
+  const prefix = child_process.execFileSync('llvm-config', [
+    '--prefix'
+  ]).toString().trim();
+  const options = JSON.stringify({
+    variables: { 'lldb_build_dir%': prefix }
+  }, null, 2);
+  fs.writeFileSync('options.gypi', options, 'utf-8');
+  console.log('Overwriting options.gypi with output from llvm-config:');
+  console.log(options);
+}
+
+function getDarwinIntallDir() {
+  var installedDir;
+  try {
+    installedDir = child_process.execFileSync('llvm-config', [
+      '--prefix'
+    ]).toString().trim();
+  } catch (err) {
+    // Return undefined, we will download the headers.
+  }
+  if (installedDir !== undefined &&
+      fs.existsSync(getLldbHeadersPath(installedDir))) {
+    return installedDir;
+  }
+  return undefined;
+}
+
 // Find the 'best' lldb to use. Either:
 // - the one specified by the user using npm --lldb_exe=... install llnode
 // - the default lldb executable
@@ -192,8 +227,10 @@ function getDarwinRelease() {
 function getLldbExecutable() {
   var lldbExe = process.env.npm_config_lldb_exe;
   if (lldbExe === undefined) {
-    var lldbExeNames = ['lldb', 'lldb-5.0', 'lldb-4.0',
-	'lldb-3.9', 'lldb-3.8', 'lldb-3.7', 'lldb-3.6'];
+    var lldbExeNames = [
+      'lldb', 'lldb-5.0', 'lldb-4.0',
+      'lldb-3.9', 'lldb-3.8', 'lldb-3.7', 'lldb-3.6'
+    ];
     for (var lldbExeVersion of lldbExeNames) {
       try {
         lldbExe = child_process.execSync('which ' +
@@ -213,7 +250,6 @@ function getLldbExecutable() {
 // There are multiple versions of lldb available for the various linux distos.
 // Use the default unless --llnode_exe= has been set on the command line.
 function getLinuxVersion(lldbExe) {
-
   var lldbStr;
   try {
     lldbStr = child_process.execFileSync(lldbExe, ['-v']).toString();
@@ -230,42 +266,42 @@ function getLinuxVersion(lldbExe) {
 
 // Shim this for consistancy in OS naming
 function getFreeBSDVersion(lldbExe) {
-   //Strip the dots for BSD
-   return getLinuxVersion(lldbExe).replace('.','');
+  // Strip the dots for BSD
+  return getLinuxVersion(lldbExe).replace('.', '');
 }
 
-function getFreeBSDHeadersDir(version) {
-
+function getFreeBSDInstallDir(version) {
   console.log('Checking for headers, version is ' + version);
 
   try {
-    var includeDir = child_process.execFileSync('llvm-config' + version,
+    var installDir = child_process.execFileSync('llvm-config' + version,
       ['--prefix']).toString().trim();
-    if (fs.existsSync(includeDir + '/include/lldb')) {
-      return includeDir;
+    if (fs.existsSync(installDir + '/include/lldb')) {
+      return installDir;
     }
   } catch (err) {
-    console.log(includeDir + '/include/lldb doesn\'nt exist');
+    console.log(installDir + '/include/lldb doesn\'nt exist');
     console.log('Please see README.md');
     console.log(err);
     process.exit(1);
   }
   return undefined;
 }
-function getLinuxHeadersDir(version) {
+
+function getLinuxInstallDir(version) {
   // Get the directory which should contain the headers and
   // check if they are present.
   // (Using the installed headers will ensure we have the correct ones.)
   console.log('Checking for headers, version is ' + version);
   try {
-    var includeDir = child_process.execFileSync('llvm-config-' + version,
+    var installDir = child_process.execFileSync('llvm-config-' + version,
       ['--prefix']).toString().trim();
     // console.log('Checking for directory ' + include_dir);
     // Include directory doesn't need include/lldb on the end but the llvm
     // headers can be installed without the lldb headers so check for them.
-    if (fs.existsSync(includeDir + '/include/lldb')) {
+    if (fs.existsSync(installDir + '/include/lldb')) {
       // console.log('Found ' + include_dir);
-      return includeDir;
+      return installDir;
     }
   } catch (err) {
     // Return undefined, we will download the headers.
@@ -278,7 +314,6 @@ function getLinuxHeadersDir(version) {
 }
 
 function scriptText(lldbExe) {
-
   let lib = 'llnode.so';
   if (osName === 'Darwin') {
     lib = 'llnode.dylib';
@@ -299,5 +334,4 @@ fi
 
 ${lldbExe} --one-line "plugin load $LLNODE_PLUGIN" --one-line "settings set prompt '(llnode) '" $@
 `;
-
 }


### PR DESCRIPTION
Previously if one has `lldb` executable set to something different from what `xcodebuild` integrates, since the plugin will be linked to the default lldb instead of the one loading it, we will get an error when running any llnode commands:

```
error: No valid process, please start something
```

This PR fixes that by detecting the lldb libraries from `llvm-config` first and use that if available. The theory is, if one has a `lldb` different from the default one, then they probably have `llvm-config` setup as well (e.g. `brew install llvm --with-lldb` and configure the PATH to use that version).

Also skip cloning the headers if they are already cloned.