### PR TITLE
test: update travis config, handle errors properly, add TEST_LLNODE_DEBUG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: required
 dist: trusty
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install lldb-3.6 lldb-3.6-dev -y
+  - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
   - git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
 node_js:
   - "4"
-  - "5"
   - "6"
-  - "7"
+  - "8"
+  - "9"
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ plugin: configure
 	$(MAKE) -C out/
 
 _travis: plugin
-	TEST_LLDB_BINARY=`which lldb-3.9` npm test
+	TEST_LLDB_BINARY=`which lldb-3.9` TEST_LLNODE_DEBUG=true npm test
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,14 @@ uninstall-linux:
 format:
 	clang-format -i src/*
 
-_travis:
-	./gyp_llnode -Dlldb_dir=/usr/lib/llvm-3.6/ -f make
-	make -C out/
-	TEST_LLDB_BINARY=`which lldb-3.6` npm test
+configure: scripts/configure.js
+	node scripts/configure.js
+
+plugin: configure
+	./gyp_llnode
+	$(MAKE) -C out/
+
+_travis: plugin
+	TEST_LLDB_BINARY=`which lldb-3.9` npm test
 
 .PHONY: all

--- a/test/frame-test.js
+++ b/test/frame-test.js
@@ -8,11 +8,13 @@ tape('v8 stack', (t) => {
   t.timeoutAfter(15000);
 
   const sess = common.Session.create('frame-scenario.js');
-  sess.waitBreak(() => {
+  sess.waitBreak((err) => {
+    t.error(err);
     sess.send('v8 bt');
   });
 
-  sess.linesUntil(/eyecatcher/, (lines) => {
+  sess.linesUntil(/eyecatcher/, (err, lines) => {
+    t.error(err);
     lines.reverse();
     t.ok(lines.length > 4, 'frame count');
     // FIXME(bnoordhuis) This can fail with versions of lldb that don't

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -190,10 +190,8 @@ tape('v8 inspect', (t) => {
         lines.indexOf('<Array: length=20'),
         -1,
         'long array length');
-      t.ok(
-          lines.match(/\[9\]=<Smi: 5>}>$/),
-          'long array content');
-      sess.send(`v8 inspect ${arrayBuffer}`);
+    t.ok(lines.match(/\[9\]=<Smi: 5>}>$/), 'long array content');
+    sess.send(`v8 inspect ${arrayBuffer}`);
   });
 
   sess.linesUntil(/\]>/, (lines) => {
@@ -286,7 +284,7 @@ tape('v8 inspect', (t) => {
     // the function we want.)
     const arrowSource = 'source:\n' +
         'function c.hashmap.(anonymous function)(a,b)=>{a+b}\n' +
-        '>'
+        '>';
 
     t.ok(lines.includes(
         arrowSource),
@@ -301,11 +299,11 @@ tape('v8 inspect', (t) => {
     // Include 'source:' and '>' to act as boundaries. (Avoid
     // passing if the whole file it displayed instead of just
     // the function we want.)
-    const methodSource = "  source:\n" +
-    "function method() {\n" +
-    "    throw new Error('Uncaught');\n" +
-    "  }\n" +
-    ">"
+    const methodSource = '  source:\n' +
+    'function method() {\n' +
+    '    throw new Error(\'Uncaught\');\n' +
+    '  }\n' +
+    '>';
 
     t.ok(lines.includes(
         methodSource),

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -9,14 +9,16 @@ tape('v8 inspect', (t) => {
 
   const sess = common.Session.create('inspect-scenario.js');
 
-  sess.waitBreak(() => {
+  sess.waitBreak((err) => {
+    t.error(err);
     sess.send('v8 bt');
   });
 
   let that = null;
   let fn = null;
 
-  sess.wait(/inspect-scenario.js/, (line) => {
+  sess.wait(/inspect-scenario.js/, (err, line) => {
+    t.error(err);
     let match = line.match(/method\(this=(0x[0-9a-f]+)[^\n]+fn=(0x[0-9a-f]+)/i);
     t.ok(match, 'method should have `this`');
 
@@ -28,11 +30,13 @@ tape('v8 inspect', (t) => {
 
   let hashmap = null;
 
-  sess.wait(/Class/, (line) => {
+  sess.wait(/Class/, (err, line) => {
+    t.error(err);
     t.notEqual(line.indexOf(that), -1, 'addr of `Class` should match');
   });
 
-  sess.linesUntil(/}>/, (lines) => {
+  sess.linesUntil(/}>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.ok(/x=<Smi: 1>/.test(lines), '.x smi property');
     t.ok(/y=123.456/.test(lines), '.y heap number property');
@@ -57,11 +61,13 @@ tape('v8 inspect', (t) => {
   let uint8Array = null;
   let buffer = null;
 
-  sess.wait(/Object/, (line) => {
+  sess.wait(/Object/, (err, line) => {
+    t.error(err);
     t.notEqual(line.indexOf(hashmap), -1, 'addr of `Object` should match');
   });
 
-  sess.linesUntil(/}>/, (lines) => {
+  sess.linesUntil(/}>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.ok(/\[0\]=[^\n]*null/.test(lines), '[0] null element');
     t.ok(/\[4\]=[^\n]*undefined/.test(lines), '[4] undefined element');
@@ -135,14 +141,16 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect -F ${cons}`);
   });
 
-  sess.linesUntil(/}>/, (lines) => {
+  sess.linesUntil(/}>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.ok(/source=\/regexp\//.test(lines) ||
              /\.source=[^\n]*<String: "regexp">/.test(lines),
          'regexp.source');
   });
 
-  sess.linesUntil(/">/, (lines) => {
+  sess.linesUntil(/">/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.notEqual(
         lines.indexOf('this could be a bit smaller, but v8 wants big str.' +
@@ -153,7 +161,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect --string-length 20 ${cons}`);
   });
 
-  sess.linesUntil(/">/, (lines) => {
+  sess.linesUntil(/">/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.notEqual(
         lines.indexOf('this could be a bit ...'),
@@ -163,7 +172,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect ${thin}`);
   });
 
-  sess.linesUntil(/">/, (lines) => {
+  sess.linesUntil(/">/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.ok(
       /0x[0-9a-f]+:<String: "foobar">/.test(lines),
@@ -172,7 +182,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect ${array}`);
   });
 
-  sess.linesUntil(/}>/, (lines) => {
+  sess.linesUntil(/}>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.notEqual(
         lines.indexOf('<Array: length=6'),
@@ -184,7 +195,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect --array-length 10 ${longArray}`);
   });
 
-  sess.linesUntil(/}>/, (lines) => {
+  sess.linesUntil(/}>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     t.notEqual(
         lines.indexOf('<Array: length=20'),
@@ -194,7 +206,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect ${arrayBuffer}`);
   });
 
-  sess.linesUntil(/\]>/, (lines) => {
+  sess.linesUntil(/\]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -207,7 +220,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect --array-length 1 ${arrayBuffer}`);
   });
 
-  sess.linesUntil(/]>/, (lines) => {
+  sess.linesUntil(/]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -220,7 +234,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect ${uint8Array}`);
   });
 
-  sess.linesUntil(/]>/, (lines) => {
+  sess.linesUntil(/]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -234,7 +249,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect --array-length 1 ${uint8Array}`);
   });
 
-  sess.linesUntil(/]>/, (lines) => {
+  sess.linesUntil(/]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -248,7 +264,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect ${buffer}`);
   });
 
-  sess.linesUntil(/]>/, (lines) => {
+  sess.linesUntil(/]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -262,7 +279,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect --array-length 1 ${buffer}`);
   });
 
-  sess.linesUntil(/]>/, (lines) => {
+  sess.linesUntil(/]>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     const re = new RegExp(
       '0x[0-9a-f]+:' +
@@ -277,7 +295,8 @@ tape('v8 inspect', (t) => {
   });
 
 
-  sess.linesUntil(/^>/, (lines) => {
+  sess.linesUntil(/^>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
     // Include 'source:' and '>' to act as boundaries. (Avoid
     // passing if the whole file it displayed instead of just
@@ -293,7 +312,8 @@ tape('v8 inspect', (t) => {
     sess.send(`v8 inspect -s ${fn}`);
   });
 
-  sess.linesUntil(/^>/, (lines) => {
+  sess.linesUntil(/^>/, (err, lines) => {
+    t.error(err);
     lines = lines.join('\n');
 
     // Include 'source:' and '>' to act as boundaries. (Avoid
@@ -331,17 +351,21 @@ tape('v8 inspect', (t) => {
     }
   });
 
-  sess.linesUntil(/}>/, (lines) => {
-    lines = lines.join('\n');
-    t.ok(/internal fields/.test(lines), 'method.scopedAPI.internalFields');
-  });
+  if (process.version >= 'v5.0.0') {
+    sess.linesUntil(/}>/, (err, lines) => {
+      t.error(err);
+      lines = lines.join('\n');
+      t.ok(/internal fields/.test(lines), 'method.scopedAPI.internalFields');
+    });
 
-  sess.linesUntil(/}>/, (lines) => {
-    lines = lines.join('\n');
-    t.ok(/outerVar[^\n]+"outer variable"/.test(lines),
-         'method.closure.outerVar');
+    sess.linesUntil(/}>/, (err, lines) => {
+      t.error(err);
+      lines = lines.join('\n');
+      t.ok(/outerVar[^\n]+"outer variable"/.test(lines),
+          'method.closure.outerVar');
 
-    sess.quit();
-    t.end();
-  });
+      sess.quit();
+      t.end();
+    });
+  }
 });

--- a/test/stack-test.js
+++ b/test/stack-test.js
@@ -12,7 +12,8 @@ tape('v8 stack', (t) => {
     sess.send('v8 bt');
   });
 
-  sess.wait(/stack-scenario.js/, (line) => {
+  sess.wait(/stack-scenario.js/, (err, line) => {
+    t.error(err);
     t.ok(/method\(this=.*Class.*method args.*Number: 1\.23.*null/.test(line),
          'Class method name and args');
 
@@ -21,7 +22,8 @@ tape('v8 stack', (t) => {
          'Class method file pos');
   });
 
-  sess.wait(/stack-scenario.js/, (line) => {
+  sess.wait(/stack-scenario.js/, (err, line) => {
+    t.error(err);
     t.ok(/third\(.*third args.*Smi: 1.*Object/.test(line),
          'Third function name and args');
 
@@ -29,7 +31,8 @@ tape('v8 stack', (t) => {
     t.ok(/stack-scenario.js:13:15/.test(line), 'Third function file pos');
   });
 
-  sess.wait(/stack-scenario.js/, (line) => {
+  sess.wait(/stack-scenario.js/, (err, line) => {
+    t.error(err);
     t.ok(/second\(.*second args.*Smi: 1/.test(line),
          'Second function name and args');
 
@@ -37,7 +40,8 @@ tape('v8 stack', (t) => {
     t.ok(/stack-scenario.js:9:16/.test(line), 'Second function file pos');
   });
 
-  sess.wait(/stack-scenario.js/, (line) => {
+  sess.wait(/stack-scenario.js/, (err, line) => {
+    t.error(err);
     t.ok(/first/.test(line), 'first function name');
 
     // TODO(indutny): line numbers are off

--- a/test/usage-test.js
+++ b/test/usage-test.js
@@ -7,30 +7,35 @@ tape('usage messages', (t) => {
 
   const sess = common.Session.create('inspect-scenario.js');
 
-  sess.waitBreak(() => {
+  sess.waitBreak((err) => {
+    t.error(err);
     sess.send('v8 print');
   });
 
-  sess.stderr.linesUntil(/USAGE/, (lines) => {
+  sess.stderr.linesUntil(/USAGE/, (err, lines) => {
+    t.error(err);
     const re = /^error: USAGE: v8 print expr$/;
     t.ok(lines.some(line => re.test(line.trim())), 'print usage message');
     sess.send('v8 source list');
   });
 
-  sess.stderr.linesUntil(/USAGE/, (lines) => {
+  sess.stderr.linesUntil(/USAGE/, (err, lines) => {
+    t.error(err);
     const re = /^error: USAGE: v8 source list$/;
     t.ok(lines.some(line => re.test(line.trim())), 'list usage message');
     sess.send('v8 findjsinstances');
   });
 
-  sess.stderr.linesUntil(/USAGE/, (lines) => {
+  sess.stderr.linesUntil(/USAGE/, (err, lines) => {
+    t.error(err);
     const re = /^error: USAGE: v8 findjsinstances \[flags\] instance_name$/;
     t.ok(lines.some(line => re.test(line.trim())),
          'findjsinstances usage message');
     sess.send('v8 findrefs');
   });
 
-  sess.stderr.linesUntil(/USAGE/, (lines) => {
+  sess.stderr.linesUntil(/USAGE/, (err, lines) => {
+    t.error(err);
     const re = /^error: USAGE: v8 findrefs expr$/;
     t.ok(lines.some(line => re.test(line.trim())), 'findrefs usage message');
     sess.quit();

--- a/test/usage-test.js
+++ b/test/usage-test.js
@@ -2,10 +2,6 @@
 const tape = require('tape');
 const common = require('./common');
 
-function removeBlankLines(lines) {
-  return lines.filter((line) => { return line.trim() !== ''; });
-}
-
 tape('usage messages', (t) => {
   t.timeoutAfter(15000);
 
@@ -16,28 +12,27 @@ tape('usage messages', (t) => {
   });
 
   sess.stderr.linesUntil(/USAGE/, (lines) => {
-    t.ok(/^error: USAGE: v8 print expr$/.test(removeBlankLines(lines)[0]),
-         'print usage message');
+    const re = /^error: USAGE: v8 print expr$/;
+    t.ok(lines.some(line => re.test(line.trim())), 'print usage message');
     sess.send('v8 source list');
   });
 
   sess.stderr.linesUntil(/USAGE/, (lines) => {
-    t.ok(/^error: USAGE: v8 source list$/.test(removeBlankLines(lines)[0]),
-         'list usage message');
+    const re = /^error: USAGE: v8 source list$/;
+    t.ok(lines.some(line => re.test(line.trim())), 'list usage message');
     sess.send('v8 findjsinstances');
   });
 
   sess.stderr.linesUntil(/USAGE/, (lines) => {
     const re = /^error: USAGE: v8 findjsinstances \[flags\] instance_name$/;
-
-    t.ok(re.test(removeBlankLines(lines)[0]),
+    t.ok(lines.some(line => re.test(line.trim())),
          'findjsinstances usage message');
     sess.send('v8 findrefs');
   });
 
   sess.stderr.linesUntil(/USAGE/, (lines) => {
-    t.ok(/^error: USAGE: v8 findrefs expr$/.test(removeBlankLines(lines)[0]),
-         'findrefs usage message');
+    const re = /^error: USAGE: v8 findrefs expr$/;
+    t.ok(lines.some(line => re.test(line.trim())), 'findrefs usage message');
     sess.quit();
     t.end();
   });

--- a/test/usage-test.js
+++ b/test/usage-test.js
@@ -2,6 +2,10 @@
 const tape = require('tape');
 const common = require('./common');
 
+function containsLine(lines, re) {
+  return lines.some(line => re.test(line.trim()));
+}
+
 tape('usage messages', (t) => {
   t.timeoutAfter(15000);
 
@@ -15,29 +19,28 @@ tape('usage messages', (t) => {
   sess.stderr.linesUntil(/USAGE/, (err, lines) => {
     t.error(err);
     const re = /^error: USAGE: v8 print expr$/;
-    t.ok(lines.some(line => re.test(line.trim())), 'print usage message');
+    t.ok(containsLine(lines, re), 'print usage message');
     sess.send('v8 source list');
   });
 
   sess.stderr.linesUntil(/USAGE/, (err, lines) => {
     t.error(err);
     const re = /^error: USAGE: v8 source list$/;
-    t.ok(lines.some(line => re.test(line.trim())), 'list usage message');
+    t.ok(containsLine(lines, re), 'list usage message');
     sess.send('v8 findjsinstances');
   });
 
   sess.stderr.linesUntil(/USAGE/, (err, lines) => {
     t.error(err);
     const re = /^error: USAGE: v8 findjsinstances \[flags\] instance_name$/;
-    t.ok(lines.some(line => re.test(line.trim())),
-         'findjsinstances usage message');
+    t.ok(containsLine(lines, re), 'findjsinstances usage message');
     sess.send('v8 findrefs');
   });
 
   sess.stderr.linesUntil(/USAGE/, (err, lines) => {
     t.error(err);
     const re = /^error: USAGE: v8 findrefs expr$/;
-    t.ok(lines.some(line => re.test(line.trim())), 'findrefs usage message');
+    t.ok(containsLine(lines, re), 'findrefs usage message');
     sess.quit();
     t.end();
   });


### PR DESCRIPTION
At the moment when a test times out (usually because the expected lldb output does not show up, possible due to an error), there is only a tape timeout message, as is what's happening in our Travis CI build.

This PR checks the timeout and throws an error containing the lldb output for the ease of debugging.

I've tried it on Mac and Linux with v8.9.0 and v6.11.5. I've noticed that the tests are a bit flaky in master, with random timeouts (with this patch on I can see the sent command got swallowed, it's `8 <command>` instead of `v8 <command>` so lldb will error and the test times out). Sometimes there is a ECONNRESET on the pipe. I'll investigate that later.