### PR TITLE
src: improve debug info printed when LLNODE_DEBUG=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,53 @@
+TEST_LLDB_BINARY ?= $(shell which lldb-3.9)
+
+.PHONY: all
 all:
 	@echo "Please take a look at README.md"
 
+.PHONY: install-osx
 install-osx:
 	mkdir -p ~/Library/Application\ Support/LLDB/PlugIns/
 	cp -rf ./out/Release/llnode.dylib \
 		~/Library/Application\ Support/LLDB/PlugIns/
 
+.PHONY: uninstall-osx
 uninstall-osx:
 	rm ~/Library/Application\ Support/LLDB/PlugIns/llnode.dylib
 
+.PHONY: install-linux
 install-linux:
 	mkdir -p /usr/lib/lldb/plugins
 	cp -rf ./out/Release/lib.target/llnode.so /usr/lib/lldb/plugins
 
+.PHONY: uninstall-linux
 uninstall-linux:
 	rm /usr/lib/lldb/plugins/llnode.so
 
+.PHONY: format
 format:
 	clang-format -i src/*
 
-configure: scripts/configure.js
+# This depends on the system setting e.g. $PATH so can't actually be skipped
+.PHONY: configure
+configure:
 	node scripts/configure.js
-
-plugin: configure
 	./gyp_llnode
+
+.PHONY: plugin
+plugin: configure
 	$(MAKE) -C out/
+	node scripts/cleanup.js
 
-_travis: plugin
-	TEST_LLDB_BINARY=`which lldb-3.9` TEST_LLNODE_DEBUG=true npm test
+.PHONY: _travis
+_travis:
+	TEST_LLDB_BINARY="$(TEST_LLDB_BINARY)" \
+	TEST_LLNODE_DEBUG=true \
+	LLNODE_DEBUG=true \
+	npm test
 
-.PHONY: all
+.PHONY: clean
+clean:
+	$(RM) -r out
+	$(RM) options.gypi
+	$(RM) lldb
+	$(RM) llnode.so llnode.dylib

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "git+ssh://git@github.com/nodejs/llnode.git"
   },
   "files": [
+    "Makefile",
     "llnode.gyp.json",
     "gyp_llnode",
     "common.gypi",

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -299,11 +299,24 @@ bool ListCmd::DoExecute(SBDebugger d, char** cmd,
   return true;
 }
 
+
+void InitDebugMode() {
+  bool is_debug_mode = false;
+  char* var = getenv("LLNODE_DEBUG");
+  if (var != nullptr && strlen(var) != 0) {
+    is_debug_mode = true;
+  }
+
+  v8::Error::SetDebugMode(is_debug_mode);
+}
+
 }  // namespace llnode
 
 namespace lldb {
 
 bool PluginInitialize(SBDebugger d) {
+  llnode::InitDebugMode();
+
   SBCommandInterpreter interpreter = d.GetCommandInterpreter();
 
   SBCommand v8 = interpreter.AddMultiwordCommand("v8", "Node.js helpers");

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -1,6 +1,7 @@
 #ifndef SRC_LLV8_INL_H_
 #define SRC_LLV8_INL_H_
 
+#include <cinttypes>
 #include "llv8.h"
 
 namespace llnode {
@@ -19,7 +20,9 @@ inline T LLV8::LoadValue(int64_t addr, Error& err) {
 
   T res = T(this, ptr);
   if (!res.Check()) {
-    err = Error::Failure("Invalid value");
+    // TODO(joyeecheung): use Error::Failure() to report information when
+    // there is less noise from here.
+    err = Error(true, "Invalid value");
     return T();
   }
 
@@ -63,7 +66,8 @@ inline T HeapObject::LoadFieldValue(int64_t off, Error& err) {
   T res = v8()->LoadValue<T>(LeaField(off), err);
   if (err.Fail()) return T();
   if (!res.Check()) {
-    err = Error::Failure("Invalid value");
+    err = Error::Failure("Invalid field value %s at 0x%016" PRIx64,
+                         T::ClassName(), off);
     return T();
   }
 


### PR DESCRIPTION
Part of my investigation of https://github.com/nodejs/llnode/issues/143, but I think we can get this in first. This helps finding the missing symbols and unknown types so we would know what metadata needs an update .

Refs: https://github.com/nodejs/post-mortem/issues/50

cc @cjihrig @bnoordhuis 

BTW here is the ouput of `LLNODE_CORE=core.inspect.8.9.0 LLNODE_NODE_EXE=node.linux.8.9.0 gmake _travis > /dev/null |& grep llv8 > out.txt` with Node v9.2.0 on MacOS (I used prepared core file and a linux binary to speed up the `scan-test`), the `Unknown HeapObject Type 211` is from my local changes (the `Error` type).

```
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_off_fp_marker
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_SharedFunctionInfo__inferred_name__String
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_off_fp_marker
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_SharedFunctionInfo__inferred_name__String
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_prop_type_mask
[TEST][13193] [stderr] [llv8] Failed to load raw constant prop_type_mask
[TEST][13193] [stderr] [llv8] Unknown HeapObject Type 211 at 0x0000357d8ed67e01
[TEST][13193] [stderr] [llv8] Unknown field Type 4614
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_Context__closure_index__int
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_Context__previous_index__int
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_Context__min_context_slots__int
[TEST][13193] [stderr] [llv8] Unknown field Type 518
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_SharedFunctionInfo__inferred_name__String
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_prop_type_mask
[TEST][13193] [stderr] [llv8] Failed to load raw constant prop_type_mask
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_NameDictionaryShape__entry_size__int
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_NameDictionary__prefix_start_index__int
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_NameDictionaryShape__prefix_size__int
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_off_fp_marker
[TEST][13193] [stderr] [llv8] Failed to find symbol v8dbg_class_SharedFunctionInfo__inferred_name__String
```