### PR TITLE
Switch to LLDB 3.9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ make install-osx
 git clone https://github.com/nodejs/llnode.git && cd llnode
 
 # Install lldb and headers
-sudo apt-get install lldb-3.8 lldb-3.8-dev
+sudo apt-get install lldb-3.9 liblldb-3.9-dev
 
 # Initialize GYP
 git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
 
 # Configure
-./gyp_llnode -Dlldb_dir=/usr/lib/llvm-3.8/
+./gyp_llnode -Dlldb_dir=/usr/lib/llvm-3.9/
 
 # Build
 make -C out/ -j9


### PR DESCRIPTION
I think it's safe to assume most users will want LLDB 3.9 due to #140.

Tested on Ubuntu 16.04.3 LTS (Xenial).