### PR TITLE
src: support loading symbols from shared libraries

### DIFF
--- a/test/fixtures/d8-scenario.js
+++ b/test/fixtures/d8-scenario.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// This file is supposed to be run in the d8 shell, so no Node.js API is
+// used here.
+// To enable post-mortem support in d8, build it with
+// v8_postmortem_support = true.
+// Run this file with `lldb -- d8 --abort_on_uncaught_exception d8-scenario.js`
+
+class Class {
+  constructor() {
+    this.x = 1;
+    this.y = 123.456;
+
+    this.hashmap = {};
+  }
+
+  method(num, str, arr) {
+    this.hashmap['some-key'] = num;
+    this.hashmap['other-key'] = str;
+    this.hashmap['cons-string'] =
+      'this could be a bit smaller, but v8 wants big str.';
+    this.hashmap['cons-string'] += this.hashmap['cons-string'];
+    this.hashmap['internalized-string'] = 'foobar';
+
+    this.hashmap['array'] = [true, 1, undefined, null, 'test', Class];
+    this.hashmap['long-array'] = arr;
+    this.hashmap['array-buffer'] = new Uint8Array(
+      [0x01, 0x02, 0x03, 0x04, 0x05]
+    ).buffer;
+    this.hashmap['uint8-array'] = new Uint8Array(
+      [0x01, 0x40, 0x60, 0x80, 0xf0, 0xff]
+    );
+
+    this.hashmap[0] = null;
+    this.hashmap[4] = undefined;
+    this.hashmap[23] = /regexp/;
+    this.hashmap[25] = (a, b) => a + b;
+    throw new Error('Uncaught');
+  }
+}
+
+function closure() {
+  const c = new Class();
+  c.method(42, 'ohai', new Array(20).fill(5));
+}
+
+closure();


### PR DESCRIPTION
This enables support for loading symbols from shared libraries, e.g. d8 with libv8 and friends.

Below is the debug session in d8 with the simplified d8-scenario.js, I didn't include things like thin strings because some metadata changes needed are floated in node's 6.2 branch.

Tested on macos and ubuntu 16.04 with the d8 built from v8 6.2 branch head. <del>Inspecting the function source  does not work at the moment, but the related symbols loaded are the same as node v9.2, and it seems to be related to https://github.com/nodejs/llnode/issues/138 </del> (It works, but `v8 i -s <function>` doesn't, even though `v8 print <function>` and `v8 source list <function>`  works, see https://github.com/nodejs/llnode/issues/153#issuecomment-348989466) so I think that can be fixed in another PR.

Fixes: https://github.com/nodejs/llnode/issues/153

<details>
<summary>See d8 debug session (v8 version 6.2.414.46, 6.2 branch head)</summary>

```
> lldb -- ./d8 --abort_on_uncaught_exception ../../../llnode/test/fixtures/d8-scenario.js
(lldb) target create "./d8"
Current executable set to './d8' (x86_64).
(lldb) settings set -- target.run-args  "--abort_on_uncaught_exception" "../../../llnode/test/fixtures/d8-scenario.js"
(lldb) run
Process 82242 launched: './d8' (x86_64)
Uncaught Error: Uncaught

FROM
Class.method (../../../llnode/test/fixtures/d8-scenario.js:1:1)
closure (../../../llnode/test/fixtures/d8-scenario.js:1:1)
../../../llnode/test/fixtures/d8-scenario.js:1:1
Process 82242 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x000000010340df61 libv8_libbase.dylib`v8::base::OS::Abort() at platform-posix.cc:248
   245
   246 	void OS::Abort() {
   247 	  if (g_hard_abort) {
-> 248 	    V8_IMMEDIATE_CRASH();
   249 	  }
   250 	  // Redirect to std abort to signal abnormal program termination.
   251 	  abort();
(lldb) v8 bt
 * thread #1: tid = 0x1815ff, 0x000000010340df61 libv8_libbase.dylib`v8::base::OS::Abort() at platform-posix.cc:248, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x000000010340df61 libv8_libbase.dylib`v8::base::OS::Abort() at platform-posix.cc:248
    frame #1: 0x0000000100df20c3 libv8.dylib`v8::internal::Isolate::Throw(this=0x0000000106800000, exception=0x00002c9358f8f1a9, location=0x00007fff5fbfdfd8) at isolate.cc:1159
    frame #2: 0x000000010116aff1 libv8.dylib`v8::internal::__RT_impl_Runtime_Throw(args=Arguments @ 0x00007fff5fbfe108, isolate=0x0000000106800000) at runtime-internal.cc:71
    frame #3: 0x000000010116ac8e libv8.dylib`v8::internal::Runtime_Throw(args_length=1, args_object=0x00007fff5fbfe1c8, isolate=0x0000000106800000) at runtime-internal.cc:68
    frame #4: 0x000037b0309043c4 <exit>
    frame #5: 0x000037b030a6f321 <stub>
    frame #6: 0x000037b0309f15a0 method(this=0x00002c9358f8ca29:<Object: Class>, <Smi: 42>, 0x00002c93d4dac9f1:<String: "ohai">, 0x00002c9358f8cbc1:<Array: length=20>) at ../../../llnode/test/fixtures/d8-scenario.js:17:9 fn=0x00002c9358f8c959
    frame #7: 0x000037b0309f15a0 closure(this=0x00002c93f38822d1:<undefined>) at ../../../llnode/test/fixtures/d8-scenario.js:42:17 fn=0x00002c93d4dac879
    frame #8: 0x000037b0309f15a0 (anonymous)(this=0x00002c9358f83231:<Global proxy>) at ../../../llnode/test/fixtures/d8-scenario.js:1:0 fn=0x00002c93d4dac749
    frame #9: 0x000037b030904259 <internal>
    frame #10: 0x000037b030904101 <entry>
    frame #11: 0x0000000100b4c88c libv8.dylib`v8::internal::(anonymous namespace)::Invoke(isolate=0x0000000106800000, is_construct=false, target=Handle<v8::internal::Object> @ 0x00007fff5fbfe590, receiver=Handle<v8::internal::Object> @ 0x00007fff5fbfe588, argc=0, args=0x0000000000000000, new_target=Handle<v8::internal::Object> @ 0x00007fff5fbfe580, message_handling=kReport) at execution.cc:145
    frame #12: 0x0000000100b4c0d8 libv8.dylib`v8::internal::(anonymous namespace)::CallInternal(isolate=0x0000000106800000, callable=Handle<v8::internal::Object> @ 0x00007fff5fbfe680, receiver=Handle<v8::internal::Object> @ 0x00007fff5fbfe678, argc=0, argv=0x0000000000000000, message_handling=kReport) at execution.cc:181
    frame #13: 0x0000000100b4bf64 libv8.dylib`v8::internal::Execution::Call(isolate=0x0000000106800000, callable=Handle<v8::internal::Object> @ 0x00007fff5fbfe6e0, receiver=Handle<v8::internal::Object> @ 0x00007fff5fbfe6d8, argc=0, argv=0x0000000000000000) at execution.cc:191
    frame #14: 0x000000010019218d libv8.dylib`v8::Script::Run(this=0x00000001048038d8, context=(val_ = 0x00000001048038a8)) at api.cc:2069
    frame #15: 0x0000000100007a0c d8`v8::Shell::ExecuteString(isolate=0x0000000106800000, source=(val_ = 0x00000001048038a0), name=(val_ = 0x0000000104803898), print_result=false, report_exceptions=true) at d8.cc:577
    frame #16: 0x000000010001bb79 d8`v8::SourceGroup::Execute(this=0x0000000103c01ff8, isolate=0x0000000106800000) at d8.cc:2357
    frame #17: 0x000000010001fdbd d8`v8::Shell::RunMain(isolate=0x0000000106800000, argc=3, argv=0x00007fff5fbff070, last_run=true) at d8.cc:2795
    frame #18: 0x000000010002215a d8`v8::Shell::Main(argc=3, argv=0x00007fff5fbff070) at d8.cc:3242
    frame #19: 0x0000000100022512 d8`main(argc=3, argv=0x00007fff5fbff070) at d8.cc:3274
    frame #20: 0x00007fffac0c1235 libdyld.dylib`start + 1
(lldb) v8 i 0x00002c9358f8ca29
0x00002c9358f8ca29:<Object: Class properties {
    .x=<Smi: 1>,
    .y=123.456000,
    .hashmap=0x00002c9358f8cb21:<Object: Object>}>
(lldb) v8 i 0x00002c9358f8cb21
0x00002c9358f8cb21:<Object: Object elements {
    [0]=0x00002c93f3882201:<null>,
    [4]=0x00002c93f38822d1:<undefined>,
    [23]=0x00002c9358f8d721:<JSRegExp source=/regexp/>,
    [25]=0x00002c93d4dae799:<function: hashmap.(anonymous function) at ../../../llnode/test/fixtures/d8-scenario.js:37:24>}
  properties {
    .some-key=<Smi: 42>,
    .other-key=0x00002c93d4dac9f1:<String: "ohai">,
    .cons-string=0x00002c9358f8ce99:<String: "this could be a ...">,
    .internalized-string=0x00002c93d4dad311:<String: "foobar">,
    .array=0x00002c9358f8cf81:<Array: length=6>,
    .long-array=0x00002c9358f8cbc1:<Array: length=20>,
    .array-buffer=0x00002c9358f8d2b9:<ArrayBuffer: backingStore=0x0000000103d010d0, byteLength=5>,
    .uint8-array=0x00002c9358f8d449:<ArrayBufferView [neutered]>}>
```
</details>