### PR TITLE
src: add a detailed output to findjsobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ The following subcommands are supported:
       findjsinstances -- List every object with the specified type name.
                          Use -v or --verbose to display detailed `v8 inspect` output for each object.
                          Accepts the same options as `v8 inspect`
-      findjsobjects   -- List all object types and instance counts grouped by typename and sorted by instance count.
+      findjsobjects   -- List all object types and instance counts grouped by typename and sorted by instance count. Use
+                         -d or --detailed to get an output grouped by type name, properties, and array length, as well as
+                         more information regarding each type.
                          With lldb < 3.9, requires the `LLNODE_RANGESFILE` environment variable to be set to a file
                          containing memory ranges for the core file being debugged.
                          There are scripts for generating this file on Linux and Mac in the scripts directory of the llnode

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -39,6 +39,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       {"print-map", no_argument, nullptr, 'm'},
       {"print-source", no_argument, nullptr, 's'},
       {"verbose", no_argument, nullptr, 'v'},
+      {"detailed", no_argument, nullptr, 'd'},
       {nullptr, 0, nullptr, 0}};
 
   int argc = 1;
@@ -56,7 +57,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, args, "Fmsvl:", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fmsdvl:", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
@@ -72,6 +73,7 @@ char** CommandBase::ParseInspectOptions(char** cmd,
       case 's':
         options->print_source = true;
         break;
+      case 'd':
       case 'v':
         options->detailed = true;
         break;
@@ -358,8 +360,10 @@ bool PluginInitialize(SBDebugger d) {
                          "Alias for `v8 source list`");
 
   v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
-                "List all object types and instance counts grouped by type"
-                "name and sorted by instance count.\n"
+                "List all object types and instance counts grouped by type "
+                "name and sorted by instance count. Use -d or --detailed to "
+                "get an output grouped by type name, properties, and array "
+                "length, as well as more information regarding each type.\n"
 #ifndef LLDB_SBMemoryRegionInfoList_h_
                 "Requires `LLNODE_RANGESFILE` environment variable to be set "
                 "to a file containing memory ranges for the core file being "

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1197,7 +1197,8 @@ void FindJSObjectsVisitor::InsertOnDetailedMapsToInstances(
   // No entry in the map, create a new one.
   if (*pp == nullptr) {
     auto type_name_with_three_properties = map_info.GetTypeNameWithProperties(
-        MapCacheEntry::kDontShowArrayLength, 3);
+        MapCacheEntry::kDontShowArrayLength,
+        kNumberOfPropertiesForDetailedOutput);
     *pp = new DetailedTypeRecord(type_name_with_three_properties,
                                  map_info.own_descriptors_count_,
                                  map_info.indexed_properties_count_);

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -219,6 +219,9 @@ class FindJSObjectsVisitor : MemoryVisitor {
   uint32_t FoundCount() { return found_count_; }
 
  private:
+  // TODO (mmarchini): this could be an option for findjsobjects
+  static const size_t kNumberOfPropertiesForDetailedOutput = 3;
+
   struct MapCacheEntry {
     enum ShowArrayLength { kShowArrayLength, kDontShowArrayLength };
 
@@ -249,7 +252,7 @@ class FindJSObjectsVisitor : MemoryVisitor {
   uint32_t address_byte_size_;
   uint32_t found_count_;
 
-  LLScan* llscan_;
+  LLScan* const llscan_;
   std::map<int64_t, MapCacheEntry> map_cache_;
 };
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -221,7 +221,7 @@ class FindJSObjectsVisitor : MemoryVisitor {
     uint64_t own_descriptors_count_ = 0;
     uint64_t indexed_properties_count_ = 0;
 
-    std::unique_ptr<std::string> GetTypeNameWithProperties(
+    std::string GetTypeNameWithProperties(
         ShowArrayLength show_array_length = kShowArrayLength,
         size_t max_properties = 0);
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -211,6 +211,14 @@ typedef std::map<std::string, DetailedTypeRecord*> DetailedTypeRecordMap;
 
 class FindJSObjectsVisitor : MemoryVisitor {
  public:
+  FindJSObjectsVisitor(lldb::SBTarget& target, LLScan* llscan);
+  ~FindJSObjectsVisitor() {}
+
+  uint64_t Visit(uint64_t location, uint64_t word);
+
+  uint32_t FoundCount() { return found_count_; }
+
+ private:
   struct MapCacheEntry {
     enum ShowArrayLength { kShowArrayLength, kDontShowArrayLength };
 
@@ -228,16 +236,8 @@ class FindJSObjectsVisitor : MemoryVisitor {
     bool Load(v8::Map map, v8::HeapObject heap_object, v8::Error& err);
   };
 
-  FindJSObjectsVisitor(lldb::SBTarget& target, LLScan* llscan);
-  ~FindJSObjectsVisitor() {}
-
-  uint64_t Visit(uint64_t location, uint64_t word);
-
-  uint32_t FoundCount() { return found_count_; }
-
   static bool IsAHistogramType(v8::Map& map, v8::Error& err);
 
- private:
   void InsertOnMapsToInstances(uint64_t word, v8::Map map,
                                FindJSObjectsVisitor::MapCacheEntry map_info,
                                v8::Error& err);

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -181,7 +181,7 @@ class TypeRecord {
 
 
  private:
-  friend DetailedTypeRecord;
+  friend class DetailedTypeRecord;
   std::string type_name_;
   uint64_t instance_count_;
   uint64_t total_instance_size_;
@@ -195,8 +195,8 @@ class DetailedTypeRecord : public TypeRecord {
       : TypeRecord(type_name),
         own_descriptors_count_(own_descriptors_count),
         indexed_properties_count_(indexed_properties_count) {}
-  const uint64_t GetOwnDescriptorsCount() { return own_descriptors_count_; };
-  const uint64_t GetIndexedPropertiesCount() {
+  uint64_t GetOwnDescriptorsCount() const { return own_descriptors_count_; };
+  uint64_t GetIndexedPropertiesCount() const {
     return indexed_properties_count_;
   };
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -12,6 +12,7 @@ namespace llnode {
 
 class FindJSObjectsVisitor;
 class FindReferencesCmd;
+class FindObjectsCmd;
 
 namespace v8 {
 
@@ -550,6 +551,7 @@ class LLV8 {
   friend class JSDate;
   friend class CodeMap;
   friend class llnode::FindJSObjectsVisitor;
+  friend class llnode::FindObjectsCmd;
   friend class llnode::FindReferencesCmd;
 };
 

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -75,6 +75,17 @@ function test(executable, core, t) {
     t.error(err);
     t.ok(/\d+ Zlib/.test(lines.join('\n')), 'Zlib should be in findjsobjects');
 
+    sess.send('v8 findjsobjects -d');
+    // Just a separator
+    sess.send('version');
+  });
+
+  sess.linesUntil(versionMark, (err, lines) => {
+    t.error(err);
+    t.ok(/0 +0 Zlib/.test(lines.join('\n')), 'Zlib should be in findjsobjects -d');
+    t.ok(/1 +0 Zlib: onerror/.test(lines.join('\n')),
+         '"Zlib: onerror" should be in findjsobjects -d');
+
     sess.send('v8 findjsinstances Zlib');
     // Just a separator
     sess.send('version');


### PR DESCRIPTION
Add a detailed output to findjsobjects. Inspired on mdb_v8 output, which
prints a representative object, the number of properties and array
indexes, and the first few properties for a map. This option will also
group types by its properties instead of only grouping by constructor
name.

Fixes: https://github.com/nodejs/llnode/issues/149