### PR TITLE
src: add note about remove frame type

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -542,6 +542,7 @@ void Frame::Load() {
   kExitFrame = LoadConstant("frametype_ExitFrame");
   kInternalFrame = LoadConstant("frametype_InternalFrame");
   kConstructFrame = LoadConstant("frametype_ConstructFrame");
+  // NOTE: The JavaScript frame type was removed in V8 6.3.158.
   kJSFrame = LoadConstant("frametype_JavaScriptFrame");
   kOptimizedFrame = LoadConstant("frametype_OptimizedFrame");
   kStubFrame = LoadConstant("frametype_StubFrame");


### PR DESCRIPTION
I'm not sure if we want to note these types of things or not. The JavaScript frame type was removed in https://github.com/v8/v8/commit/c5295b0d71b2024423dbd5c954acd12eceb8f657#diff-a6fe1dc6ffc293ad02ba0491647dfef5.

Even if this doesn't land, I guess this PR is now a record.