### PR TITLE
docs: update installation, loading, developing and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,86 @@ The following subcommands are supported:
 For more help on any particular subcommand, type 'help <command> <subcommand>'.
 ```
 
+## Develop and Test
+
+### Configure and Build
+
+The easiest way to build the plugin:
+
+```bash
+# Clone this repo
+git clone https://github.com/nodejs/llnode.git && cd llnode
+
+# Configure and build the plugin
+npm install
+# Or run
+make plugin
+```
+
+To configure the build yourself:
+
+```bash
+# Detect available LLDB installation and download headers if necessary
+node scripts/configure.js
+
+# To configure with the detected LLDB installation
+./gyp_llnode
+# To configure with a specified LLDB installation on OS X/macOS
+./gyp_llnode -Dlldb_build_dir=/usr/local/Cellar/llvm/5.0.0
+# To configure with a specified LLDB installation on Linux
+./gyp_llnode -Dlldb_dir=/usr/lib/llvm-3.9/
+# To configure with a specified LLDB installation on FreeBSD
+./gyp_llnode -Dlldb_dir=/usr/local/llvm39/
+
+# Build
+make -C out/ -j9
+
+# Move the built plugin to the project directory
+node scripts/cleanup.js
+```
+
+### Test
+
+To run the tests, if `lldb` is an executable on the `PATH`:
+
+```bash
+npm run test
+```
+
+If the LLDB executable is named differently, point `TEST_LLDB_BINARY`
+to it:
+
+```bash
+TEST_LLDB_BINARY=`which lldb-4.0` npm run test
+```
+
+### Useful Environment Variables
+
+* `LLNODE_DEBUG=true` to see additional debug info from llnode 
+* `TEST_LLNODE_DEBUG=true` to see additional debug info coming from the tests
+* `LLNODE_CORE=/path/to/core/dump LLNODE_NODE_EXE=/path/to/node LLNODE_NO_RANGES=true`
+  to use a prepared core dump instead of generating one on-the-fly when running
+  the tests.
+
+For example, to inspect the process of `inspect-scenario.js`, run:
+
+```bash
+LLNODE_DEBUG=true lldb -- \
+  node --abort_on_uncaught_exception --expose_externalize_string \
+  test/fixtures/inspect-scenario.js
+(lldb) run
+```
+
+To debug `test/scan-test.js` with a prepared core dump:
+
+```
+LLNODE_DEBUG=true TEST_LLNODE_DEBUG=true \
+  LLNODE_CORE=/path/to/core/dump/of/inspect/scenario.js \
+  LLNODE_NODE_EXE=/path/to/node \
+  LLNODE_NO_RANGES=true \
+  node test/scan-test.js
+```
+
 ## LICENSE
 
 This software is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # llnode
 
-[![Build Status](https://travis-ci.org/nodejs/llnode.svg?branch=master)](https://travis-ci.org/nodejs/llnode)
+[![npm](https://img.shields.io/npm/v/llnode.svg?style=flat-square)](https://npmjs.org/package/llnode)
+[![Build Status](https://img.shields.io/travis/nodejs/llnode.svg?style=flat-square)](https://travis-ci.org/nodejs/llnode)
 
 Node.js v4.x-v8.x C++ plugin for the [LLDB](http://lldb.llvm.org) debugger.
 


### PR DESCRIPTION
- doc: add npm badge and use flat square style
- doc: update installation and loading instructions
  - Update the prerequisites for each OS, on macOS one can use
    brew to install custom versions of lldb, also the shared library
    should be installed as well.
  - It's no longer necessary to download GYP and lldb headers manually
    since the configure scripts would handle all of that
  - Mention using `lldbinit` to load the plugin automatically, list
    different approaches to load the plugin.
- doc: add section about developing and testing
