### PR TITLE
test: move core saving and loading into common.js

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -224,11 +224,11 @@ exports.saveCore = function saveCore(options, cb) {
     }
     sess.quit();
 
-    if (!process.env.LLNODE_NO_RANGES) {
-      const ranges = core + '.ranges';
-      exports.generateRanges(core, ranges, cb);
-    } else {
+    if (process.env.LLNODE_NO_RANGES) {
       cb(null);
+    } else {
+      const ranges = core + '.ranges';
+      exports.generateRanges(core, ranges, cb); 
     }
   });
 }
@@ -267,11 +267,6 @@ Session.prototype.quit = function quit() {
 
   this.send('quit');
 };
-
-Session.prototype.quitWithCore = function quitWithCore() {
-  this.send('target delete 0');
-  this.quit();
-}
 
 Session.prototype.send = function send(line, callback) {
   debug(`[SEND][${this.lldb.pid}]`, line);

--- a/test/common.js
+++ b/test/common.js
@@ -209,8 +209,7 @@ exports.saveCore = function saveCore(options, cb) {
   const core = options.core || exports.core;
 
   // Create a core and test
-  let sess = Session.create(scenario);
-  let ranges;
+  const sess = Session.create(scenario);
   sess.timeoutAfter(exports.saveCoreTimeout);
 
   sess.waitBreak(() => {

--- a/test/common.js
+++ b/test/common.js
@@ -98,7 +98,7 @@ SessionOutput.prototype.wait = function wait(regexp, callback, allLines) {
 
   function onLine(line) {
     lines.push(line);
-    debug('[LINE]', line);
+    debug(`[LINE][${self.session.lldb.pid}]`, line);
 
     if (!regexp.test(line))
       return;
@@ -204,12 +204,49 @@ Session.create = function create(scenario) {
   return new Session({ scenario: scenario });
 };
 
-Session.loadCore = function loadCore(executable, core, ranges) {
-  return new Session({
+exports.saveCore = function saveCore(options, cb) {
+  const scenario = options.scenario;
+  const core = options.core || exports.core;
+
+  // Create a core and test
+  let sess = Session.create(scenario);
+  let ranges;
+  sess.timeoutAfter(exports.saveCoreTimeout);
+
+  sess.waitBreak(() => {
+    sess.send(`process save-core ${core}`);
+    // Just a separator
+    sess.send('version');
+  });
+
+  sess.wait(/lldb-/, (err) => {
+    if (err) {
+      return cb(err);
+    }
+    sess.quit();
+
+    if (!process.env.LLNODE_NO_RANGES) {
+      const ranges = core + '.ranges';
+      exports.generateRanges(core, ranges, cb);
+    } else {
+      cb(null);
+    }
+  });
+}
+
+// Load the core dump with the executable
+Session.loadCore = function loadCore(executable, core, cb) {
+  const ranges = process.env.LLNODE_NO_RANGES ? undefined : core + '.ranges';
+  const sess = new Session({
     executable: executable,
     core: core,
     ranges: ranges
   });
+
+  sess.timeoutAfter(exports.loadCoreTimeout);
+  sess.waitCoreLoad(cb);
+
+  return sess;
 };
 
 Session.prototype.waitCoreLoad = function waitCoreLoad(callback) {
@@ -232,8 +269,13 @@ Session.prototype.quit = function quit() {
   this.send('quit');
 };
 
+Session.prototype.quitWithCore = function quitWithCore() {
+  this.send('target delete 0');
+  this.quit();
+}
+
 Session.prototype.send = function send(line, callback) {
-  debug('[SEND]', line);
+  debug(`[SEND][${this.lldb.pid}]`, line);
   this.lldb.stdin.write(line + '\n', callback);
 };
 
@@ -252,6 +294,7 @@ exports.generateRanges = function generateRanges(core, dest, cb) {
   proc.stdout.pipe(fs.createWriteStream(dest));
 
   proc.on('exit', (status) => {
+    debug('[RANGES]', `Generated ${dest}`);
     cb(status === 0 ? null : new Error('Failed to generate ranges'));
   });
 };

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -87,7 +87,7 @@ function test(executable, core, t) {
     t.ok(/Object\.holder/.test(lines.join('\n')), 'Should find reference #2');
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');
 
-    sess.quitWithCore();
+    sess.quit();
     t.end();
   });
 }

--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -14,58 +14,22 @@ tape('v8 findrefs and friends', (t) => {
     t.skip('No `process save-core` on linux');
     t.end();
   } else {
-    saveCoreAndTest(t);
+    common.saveCore({
+      scenario: 'inspect-scenario.js'
+    }, (err) => {
+      t.error(err);
+      t.ok(true, 'Saved core');
+
+      test(process.execPath, common.core, t);
+    });
   }
 });
 
-function saveCoreAndTest(t) {
-  // Create a core and test
-  const sess = common.Session.create('inspect-scenario.js');
-  sess.timeoutAfter(common.saveCoreTimeout);
-
-  sess.waitBreak(() => {
-    sess.send(`process save-core ${common.core}`);
-    // Just a separator
-    sess.send('version');
-  });
-
-  sess.wait(versionMark, (err) => {
-    t.error(err);
-    t.ok(true, 'Saved core');
-    sess.send('target delete 0');
-    sess.quit();
-
-    test(process.execPath, common.core, t);
-  });
-}
-
 function test(executable, core, t) {
-  let sess, ranges;
-  if (process.env.LLNODE_NO_RANGES) {
-    sess = common.Session.loadCore(executable, core);
-  } else {
-    ranges = core + '.ranges';
-    sess = common.Session.loadCore(executable, core, ranges);
-  }
-  sess.timeoutAfter(common.loadCoreTimeout);
-
-  sess.waitCoreLoad((err) => {
+  const sess = common.Session.loadCore(executable, core, (err) => {
     t.error(err);
     t.ok(true, 'Loaded core');
 
-    if (ranges) {
-      common.generateRanges(core, ranges, (err) => {
-        t.error(err);
-        t.ok(true, 'Generated ranges');
-        sess.send('version');
-      });
-    } else {
-      sess.send('version');
-    }
-  });
-
-  sess.wait(versionMark, (err) => {
-    t.error(err);
     sess.send('v8 findjsobjects');
     // Just a separator
     sess.send('version');
@@ -123,8 +87,7 @@ function test(executable, core, t) {
     t.ok(/Object\.holder/.test(lines.join('\n')), 'Should find reference #2');
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');
 
-    sess.send('target delete 0');
-    sess.quit();
+    sess.quitWithCore();
     t.end();
   });
 }


### PR DESCRIPTION
This was used by https://github.com/nodejs/llnode/pull/147 to reuse the code that generates a core dump and saves it for testing, but it's worth getting merged first.

cc @cjihrig @bnoordhuis 