### PR TITLE
src: fix backtrace with v8 6.4

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -93,35 +93,39 @@ int64_t Module::LoadRawConstant(const char* name, int64_t def) {
   Error err;
   int64_t v = LookupConstant(target_, name, def, err);
   if (err.Fail()) {
-    Error::PrintInDebugMode("Failed to load raw constant %s", name);
+    Error::PrintInDebugMode(
+        "Failed to load raw constant %s, default to %" PRId64, name, def);
   }
 
   return v;
 }
 
+int64_t Module::LoadConstant(const char* name, Error& err, int64_t def) {
+  int64_t v =
+      LookupConstant(target_, (kConstantPrefix + name).c_str(), def, err);
+  return v;
+}
 
 int64_t Module::LoadConstant(const char* name, int64_t def) {
   Error err;
-  int64_t v =
-      LookupConstant(target_, (kConstantPrefix + name).c_str(), def, err);
+  int64_t v = LoadConstant(name, err, def);
   if (err.Fail()) {
-    Error::PrintInDebugMode("Failed to load constant %s", name);
+    Error::PrintInDebugMode("Failed to load constant %s, default to %" PRId64,
+                            name, def);
   }
 
   return v;
 }
-
 
 int64_t Module::LoadConstant(const char* name, const char* fallback,
                              int64_t def) {
   Error err;
-  int64_t v =
-      LookupConstant(target_, (kConstantPrefix + name).c_str(), def, err);
-  if (err.Fail())
-    v = LookupConstant(target_, (kConstantPrefix + fallback).c_str(), def, err);
+  int64_t v = LoadConstant(name, err, def);
+  if (err.Fail()) v = LoadConstant(fallback, err, def);
   if (err.Fail()) {
-    Error::PrintInDebugMode("Failed to load constant %s, fallback %s", name,
-                            fallback);
+    Error::PrintInDebugMode(
+        "Failed to load constant %s, fallback %s, default to %" PRId64, name,
+        fallback, def);
   }
 
   return v;
@@ -179,8 +183,16 @@ void HeapObject::Load() {
 
 
 void Map::Load() {
-  kInstanceAttrsOffset = LoadConstant("class_Map__instance_attributes__int",
-                                      "class_Map__instance_type__uint16_t");
+  Error err;
+  kInstanceAttrsOffset =
+      LoadConstant("class_Map__instance_attributes__int", err);
+  if (err.Fail()) {
+    kInstanceAttrsOffset = LoadConstant("class_Map__instance_type__uint16_t");
+    kMapTypeMask = 0xffff;
+  } else {
+    kMapTypeMask = 0xff;
+  }
+
   kMaybeConstructorOffset =
       LoadConstant("class_Map__constructor_or_backpointer__Object",
                    "class_Map__constructor__Object");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -179,7 +179,8 @@ void HeapObject::Load() {
 
 
 void Map::Load() {
-  kInstanceAttrsOffset = LoadConstant("class_Map__instance_attributes__int");
+  kInstanceAttrsOffset = LoadConstant("class_Map__instance_attributes__int",
+                                      "class_Map__instance_type__uint16_t");
   kMaybeConstructorOffset =
       LoadConstant("class_Map__constructor_or_backpointer__Object",
                    "class_Map__constructor__Object");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -5,10 +5,14 @@
 
 namespace llnode {
 namespace v8 {
+
+class Error;
+
 namespace constants {
 
 // Forward declarations
 class Common;
+
 
 class Module {
  public:
@@ -20,6 +24,7 @@ class Module {
 
  protected:
   int64_t LoadRawConstant(const char* name, int64_t def = -1);
+  int64_t LoadConstant(const char* name, Error& err, int64_t def = -1);
   int64_t LoadConstant(const char* name, int64_t def = -1);
   int64_t LoadConstant(const char* name, const char* fallback,
                        int64_t def = -1);
@@ -83,6 +88,7 @@ class Map : public Module {
  public:
   MODULE_DEFAULT_METHODS(Map);
 
+  int64_t kMapTypeMask;
   int64_t kInstanceAttrsOffset;
   int64_t kMaybeConstructorOffset;
   int64_t kInstanceDescriptorsOffset;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -89,7 +89,7 @@ inline int64_t Map::GetType(Error& err) {
       v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceAttrsOffset), 2, err);
   if (err.Fail()) return -1;
 
-  return type;
+  return type & v8()->map()->kMapTypeMask;
 }
 
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -89,7 +89,7 @@ inline int64_t Map::GetType(Error& err) {
       v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceAttrsOffset), 2, err);
   if (err.Fail()) return -1;
 
-  return type & 0xff;
+  return type;
 }
 
 


### PR DESCRIPTION
This is the minimum patch to make llnode display stack traces
produced by v8 6.4.

<details>
<summary>Before</summary>

```
 * thread #1: tid = 0x5d87fe, 0x0000000100b5cd02 node`v8::base::OS::Abort() at platform-posix.cc:360, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x0000000100b5cd02 node`v8::base::OS::Abort() at platform-posix.cc:360 [opt]
    frame #1: 0x0000000100792d2b node`v8::internal::Runtime_Throw(int, v8::internal::Object**, v8::internal::Isolate*) [inlined] v8::internal::__RT_impl_Runtime_Throw(v8::internal::Arguments, v8::internal::Isolate*) at runtime-internal.cc:71 [opt]
    frame #2: 0x0000000100792d0a node`v8::internal::Runtime_Throw(args_length=<unavailable>, args_object=<unavailable>, isolate=0x000000010284fea8) at runtime-internal.cc:68 [opt]
    frame #3: 0x00003687b60041fd <exit>
    frame #4: 0x00003687b60b46fa <stub>
    frame #5: 0x00003687b6012e88 <non-function>
    frame #6: 0x00003687b6012e88 <non-function>
    frame #7: 0x00003687b6012e88 <non-function>
    frame #8: 0x00003687b6012e88 <non-function>
    frame #9: 0x00003687b6012e88 <non-function>
    frame #10: 0x00003687b6012e88 <non-function>
    frame #11: 0x00003687b6012e88 <non-function>
    frame #12: 0x00003687b6012e88 <non-function>
    frame #13: 0x00003687b6012e88 <non-function>
    frame #14: 0x00003687b6012e88 <non-function>
    frame #15: 0x00003687b6012e88 <non-function>
    frame #16: 0x00003687b6010798 <internal>
    frame #17: 0x00003687b600953f <entry>
    frame #18: 0x00000001004c91ec node`v8::internal::(anonymous namespace)::Invoke(isolate=0x00007fff5fbfd728, is_construct=<unavailable>, target=<unavailable>, receiver=<unavailable>, argc=1, args=0x00007fff5fbfe080, new_target=<unavailable>, message_handling=<unavailable>) at execution.cc:142 [opt]
    frame #19: 0x00000001004c8f02 node`v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [inlined] v8::internal::(anonymous namespace)::CallInternal(message_handling=kReport) at execution.cc:178 [opt]
    frame #20: 0x00000001004c8e8d node`v8::internal::Execution::Call(isolate=0x0000000102801000, callable=Handle<v8::internal::Object> @ r12, receiver=<unavailable>, argc=1, argv=0x00007fff5fbfe080) at execution.cc:188 [opt]
    frame #21: 0x000000010017866f node`v8::Function::Call(this=0x000000010284fe08, context=<unavailable>, recv=<unavailable>, argc=1, argv=0x00007fff5fbfe080) at api.cc:5347 [opt]
    frame #22: 0x000000010002b1fe node`node::LoadEnvironment(env=0x00007fff5fbfe190) at node.cc:3336 [opt]
    frame #23: 0x000000010002f25c node`node::Start(isolate=0x0000000102801000, isolate_data=<unavailable>, argc=<unavailable>, argv=<unavailable>, exec_argc=2, exec_argv=0x00000001024003c0) at node.cc:4359 [opt]
    frame #24: 0x000000010002d164 node`node::Start(event_loop=0x0000000101623720, argc=2, argv=0x0000000102402750, exec_argc=2, exec_argv=0x00000001024003c0) at node.cc:4441 [opt]
    frame #25: 0x000000010002cdd3 node`node::Start(argc=<unavailable>, argv=0x0000000102402750) at node.cc:4498 [opt]
    frame #26: 0x0000000100001734 node`start + 52
```
</details>

<details>
<summary>After</summary>

```
 * thread #1: tid = 0x5d7f06, 0x0000000100b5cd02 node`v8::base::OS::Abort() at platform-posix.cc:360, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x0000000100b5cd02 node`v8::base::OS::Abort() at platform-posix.cc:360 [opt]
    frame #1: 0x0000000100792d2b node`v8::internal::Runtime_Throw(int, v8::internal::Object**, v8::internal::Isolate*) [inlined] v8::internal::__RT_impl_Runtime_Throw(v8::internal::Arguments, v8::internal::Isolate*) at runtime-internal.cc:71 [opt]
    frame #2: 0x0000000100792d0a node`v8::internal::Runtime_Throw(args_length=<unavailable>, args_object=<unavailable>, isolate=0x00000001030500a8) at runtime-internal.cc:68 [opt]
    frame #3: 0x00001f0c253841fd <exit>
    frame #4: 0x00001f0c254346fa <stub>
    frame #5: 0x00001f0c25392e88 method(this=0x000002ef54188a51:<Object: Class>) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:27:43 fn=0x000002ef761fa719
    frame #6: 0x00001f0c25392e88 closure(this=0x000002efcfb822e1:<undefined>) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:18:17 fn=0x000002efca750989
    frame #7: 0x00001f0c25392e88 (anonymous)(this=0x000002efca74e3a9:<Object: Object>, 0x000002efca74e3a9:<Object: Object>, 0x000002efca7505a9:<function: require at (external).js:10:19>, 0x000002efca74e2f1:<Object: Module>, 0x000002efca74d621:<String: "/Users/joyee/pro...">, 0x000002efca750541:<String: "/Users/joyee/pro...">) at /Users/joyee/projects/llnode/test/fixtures/inspect-scenario.js:1:10 fn=0x000002efca750501
    frame #8: 0x00001f0c25392e88 Module._compile(this=0x000002efca74e2f1:<Object: Module>, 0x000002efca74f061:<String: "'use strict';

c...">, 0x000002efca74d621:<String: "/Users/joyee/pro...">) at module.js:627:37 fn=0x000002ef56ace279
    frame #9: 0x00001f0c25392e88 Module._extensions..js(this=0x000002efeed7df21:<Object: Object>, 0x000002efca74e2f1:<Object: Module>, 0x000002efca74d621:<String: "/Users/joyee/pro...">) at module.js:675:37 fn=0x000002ef56ace2b9
    frame #10: 0x00001f0c25392e88 Module.load(this=0x000002efca74e2f1:<Object: Module>, 0x000002efca74d621:<String: "/Users/joyee/pro...">) at module.js:569:33 fn=0x000002ef56ace1f9
    frame #11: 0x00001f0c25392e88 tryModuleLoad(this=0x000002efcfb822e1:<undefined>, 0x000002efca74e2f1:<Object: Module>, 0x000002efca74d621:<String: "/Users/joyee/pro...">) at module.js:515:23 fn=0x000002efeed08739
    frame #12: 0x00001f0c25392e88 Module._load(this=0x000002efeed084a1:<function: Module at module.js:70:16>, 0x000002efca74cc09:<String: "/Users/joyee/pro...">, 0x000002efcfb82201:<null>, 0x000002efcfb82381:<true>) at module.js:458:24 fn=0x000002ef56ace159
    frame #13: 0x00001f0c25392e88 Module.runMain(this=0x000002efeed084a1:<function: Module at module.js:70:16>) at module.js:705:26 fn=0x000002ef56ace379
    frame #14: 0x00001f0c25392e88 startup(this=0x000002efcfb822e1:<undefined>) at bootstrap_node.js:1:10 fn=0x000002ef13d262b1
    frame #15: 0x00001f0c25392e88 (anonymous)(this=0x000002efcfb82201:<null>, 0x000002ef13d04029:<Object: process>) at bootstrap_node.js:1:10 fn=0x000002ef13d263b1
    frame #16: 0x00001f0c25390798 <internal>
    frame #17: 0x00001f0c2538953f <entry>
    frame #18: 0x00000001004c91ec node`v8::internal::(anonymous namespace)::Invoke(isolate=0x00007fff5fbfd728, is_construct=<unavailable>, target=<unavailable>, receiver=<unavailable>, argc=1, args=0x00007fff5fbfe080, new_target=<unavailable>, message_handling=<unavailable>) at execution.cc:142 [opt]
    frame #19: 0x00000001004c8f02 node`v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [inlined] v8::internal::(anonymous namespace)::CallInternal(message_handling=kReport) at execution.cc:178 [opt]
    frame #20: 0x00000001004c8e8d node`v8::internal::Execution::Call(isolate=0x0000000103000c00, callable=Handle<v8::internal::Object> @ r12, receiver=<unavailable>, argc=1, argv=0x00007fff5fbfe080) at execution.cc:188 [opt]
    frame #21: 0x000000010017866f node`v8::Function::Call(this=0x0000000103050008, context=<unavailable>, recv=<unavailable>, argc=1, argv=0x00007fff5fbfe080) at api.cc:5347 [opt]
    frame #22: 0x000000010002b1fe node`node::LoadEnvironment(env=0x00007fff5fbfe190) at node.cc:3336 [opt]
    frame #23: 0x000000010002f25c node`node::Start(isolate=0x0000000103000c00, isolate_data=<unavailable>, argc=<unavailable>, argv=<unavailable>, exec_argc=2, exec_argv=0x0000000102503e40) at node.cc:4359 [opt]
    frame #24: 0x000000010002d164 node`node::Start(event_loop=0x0000000101623720, argc=2, argv=0x0000000102504570, exec_argc=2, exec_argv=0x0000000102503e40) at node.cc:4441 [opt]
    frame #25: 0x000000010002cdd3 node`node::Start(argc=<unavailable>, argv=0x0000000102504570) at node.cc:4498 [opt]
    frame #26: 0x0000000100001734 node`start + 52
```
</details>