### PR TITLE
src: do not create global llscan or global llv8

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -27,8 +27,6 @@ using lldb::SBValue;
 using lldb::eReturnStatusFailed;
 using lldb::eReturnStatusSuccessFinishResult;
 
-v8::LLV8 llv8;
-
 char** CommandBase::ParseInspectOptions(char** cmd,
                                         v8::Value::InspectOptions* options) {
   static struct option opts[] = {
@@ -105,7 +103,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
   }
 
   // Load V8 constants from postmortem data
-  llv8.Load(target);
+  llv8_->Load(target);
 
   {
     SBStream desc;
@@ -124,7 +122,7 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
 
     if (!frame.GetSymbol().IsValid()) {
       v8::Error err;
-      v8::JSFrame v8_frame(&llv8, static_cast<int64_t>(frame.GetFP()));
+      v8::JSFrame v8_frame(llv8_, static_cast<int64_t>(frame.GetFP()));
       std::string res = v8_frame.Inspect(true, err);
       if (err.Success()) {
         result.Printf("  %c frame #%u: 0x%016" PRIx64 " %s\n", star, i, pc,
@@ -196,9 +194,9 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   }
 
   // Load V8 constants from postmortem data
-  llv8.Load(target);
+  llv8_->Load(target);
 
-  v8::Value v8_value(&llv8, value.GetValueAsSigned());
+  v8::Value v8_value(llv8_, value.GetValueAsSigned());
   v8::Error err;
   std::string res = v8_value.Inspect(&inspect_options, err);
   if (err.Fail()) {
@@ -255,7 +253,7 @@ bool ListCmd::DoExecute(SBDebugger d, char** cmd,
   }
 
   // Load V8 constants from postmortem data
-  llv8.Load(target);
+  llv8_->Load(target);
   SBFrame frame = thread.GetSelectedFrame();
   SBSymbol symbol = frame.GetSymbol();
 
@@ -279,7 +277,7 @@ bool ListCmd::DoExecute(SBDebugger d, char** cmd,
 
   // V8 frame
   v8::Error err;
-  v8::JSFrame v8_frame(&llv8, static_cast<int64_t>(frame.GetFP()));
+  v8::JSFrame v8_frame(llv8_, static_cast<int64_t>(frame.GetFP()));
 
   const static uint32_t kDisplayLines = 4;
   std::string* lines = new std::string[kDisplayLines];
@@ -319,26 +317,29 @@ namespace lldb {
 bool PluginInitialize(SBDebugger d) {
   llnode::InitDebugMode();
 
+  static llnode::v8::LLV8 llv8;
+  static llnode::LLScan llscan = llnode::LLScan(&llv8);
+
   SBCommandInterpreter interpreter = d.GetCommandInterpreter();
 
   SBCommand v8 = interpreter.AddMultiwordCommand("v8", "Node.js helpers");
 
   v8.AddCommand(
-      "bt", new llnode::BacktraceCmd(),
+      "bt", new llnode::BacktraceCmd(&llv8),
       "Show a backtrace with node.js JavaScript functions and their args. "
       "An optional argument is accepted; if that argument is a number, it "
       "specifies the number of frames to display. Otherwise all frames will "
       "be dumped.\n\n"
       "Syntax: v8 bt [number]\n");
-  interpreter.AddCommand("jsstack", new llnode::BacktraceCmd(),
+  interpreter.AddCommand("jsstack", new llnode::BacktraceCmd(&llv8),
                          "Alias for `v8 bt`");
 
-  v8.AddCommand("print", new llnode::PrintCmd(false),
+  v8.AddCommand("print", new llnode::PrintCmd(&llv8, false),
                 "Print short description of the JavaScript value.\n\n"
                 "Syntax: v8 print expr\n");
 
   v8.AddCommand(
-      "inspect", new llnode::PrintCmd(true),
+      "inspect", new llnode::PrintCmd(&llv8, true),
       "Print detailed description and contents of the JavaScript value.\n\n"
       "Possible flags (all optional):\n\n"
       " * -F, --full-string    - print whole string without adding ellipsis\n"
@@ -348,18 +349,18 @@ bool PluginInitialize(SBDebugger d) {
       "string/array\n"
       "\n"
       "Syntax: v8 inspect [flags] expr\n");
-  interpreter.AddCommand("jsprint", new llnode::PrintCmd(true),
+  interpreter.AddCommand("jsprint", new llnode::PrintCmd(&llv8, true),
                          "Alias for `v8 inspect`");
 
   SBCommand source =
       v8.AddMultiwordCommand("source", "Source code information");
-  source.AddCommand("list", new llnode::ListCmd(),
+  source.AddCommand("list", new llnode::ListCmd(&llv8),
                     "Print source lines around a selected JavaScript frame.\n\n"
                     "Syntax: v8 source list\n");
-  interpreter.AddCommand("jssource", new llnode::ListCmd(),
+  interpreter.AddCommand("jssource", new llnode::ListCmd(&llv8),
                          "Alias for `v8 source list`");
 
-  v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
+  v8.AddCommand("findjsobjects", new llnode::FindObjectsCmd(&llscan),
                 "List all object types and instance counts grouped by type "
                 "name and sorted by instance count. Use -d or --detailed to "
                 "get an output grouped by type name, properties, and array "
@@ -373,23 +374,24 @@ bool PluginInitialize(SBDebugger d) {
 #endif  // LLDB_SBMemoryRegionInfoList_h_
   );
 
-  interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(),
+  interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(&llscan),
                          "Alias for `v8 findjsobjects`");
 
-  v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
+  v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(&llscan, false),
                 "List every object with the specified type name.\n"
                 "Use -v or --verbose to display detailed `v8 inspect` output "
                 "for each object.\n"
                 "Accepts the same options as `v8 inspect`");
 
-  interpreter.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
+  interpreter.AddCommand("findjsinstances",
+                         new llnode::FindInstancesCmd(&llscan, false),
                          "List all objects which share the specified map.\n");
 
-  v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
+  v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(&llscan),
                 "Print information about Node.js\n");
 
   v8.AddCommand(
-      "findrefs", new llnode::FindReferencesCmd(),
+      "findrefs", new llnode::FindReferencesCmd(&llscan),
       "Finds all the object properties which meet the search criteria.\n"
       "The default is to list all the object properties that reference the "
       "specified value.\n"

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -16,15 +16,19 @@ class CommandBase : public lldb::SBCommandPluginInterface {
 
 class BacktraceCmd : public CommandBase {
  public:
+  BacktraceCmd(v8::LLV8* llv8) : llv8_(llv8) {}
   ~BacktraceCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
+
+ private:
+  v8::LLV8* llv8_;
 };
 
 class PrintCmd : public CommandBase {
  public:
-  PrintCmd(bool detailed) : detailed_(detailed) {}
+  PrintCmd(v8::LLV8* llv8, bool detailed) : llv8_(llv8), detailed_(detailed) {}
 
   ~PrintCmd() override {}
 
@@ -32,15 +36,20 @@ class PrintCmd : public CommandBase {
                  lldb::SBCommandReturnObject& result) override;
 
  private:
+  v8::LLV8* llv8_;
   bool detailed_;
 };
 
 class ListCmd : public CommandBase {
  public:
+  ListCmd(v8::LLV8* llv8) : llv8_(llv8) {}
   ~ListCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
+
+ private:
+  v8::LLV8* llv8_;
 };
 
 }  // namespace llnode

--- a/test/common.js
+++ b/test/common.js
@@ -155,7 +155,7 @@ function Session(options) {
 
   debug('lldb binary:', lldbBin);
   if (options.scenario) {
-    this.needToKill = true;
+    this.needToKill = true;  // need to send 'kill' when quitting
     // lldb -- node scenario.js
     const args = [
       '--',
@@ -173,7 +173,7 @@ function Session(options) {
     this.lldb.stdin.write(`plugin load "${exports.llnodePath}"\n`);
     this.lldb.stdin.write('run\n');
   } else if (options.core) {
-    this.needToKill = false;
+    this.needToKill = false;  // need to send 'target delete 0' when quitting
     debug('loading core', options.core);
     // lldb node -c core
     this.lldb = spawn(lldbBin, [], {
@@ -262,8 +262,11 @@ Session.prototype.kill = function kill() {
 };
 
 Session.prototype.quit = function quit() {
-  if (this.needToKill)
+  if (this.needToKill) {
     this.send('kill'); // kill the process launched in lldb
+  } else {
+    this.send('target delete 0');  // Delete the loaded core dump
+  }
 
   this.send('quit');
 };


### PR DESCRIPTION
### test: fix hanging when testing with prepared core

When the session is created by loading a prepared core dump,
it should delete the target before quitting otherwise the
process will prompt about deleting it and will hang if it
does not receive an answer.

### src: do not create global llscan or global llv8

- Eliminates all references to the global llscan in the commands,
  only instantiate one LLScan instance in llnode.cc and pass it
  down to all commands.
- Eliminates all references to the global llv8, store it inside
  the LLScan instead, because LLScan must need a valid llv8
  (with postmortem metadata loaded) to function.
- Only instantiate a static LLScan and a static LLV8 during plugin
  initialization.


The first commit is a test fix, the second one is spinning off from https://github.com/nodejs/llnode/pull/147 so llscan.o can be linked by another module.