### PR TITLE
scripts: do not check llnode.sh into git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 npm-debug.log
 node_modules/
 options.gypi
+llnode.sh

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "bin": {
-    "llnode": "scripts/llnode.sh"
+    "llnode": "llnode.sh"
   },
   "//": "(Blame C++)",
   "scripts": {

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -139,7 +139,7 @@ fs.mkdirSync('tools');
 console.log(`Linking tools/gyp to ${gypDir}/gyp`);
 fs.symlinkSync(`${gypDir}/gyp`, 'tools/gyp');
 
-fs.writeFileSync(`${buildDir}/scripts/llnode.sh`, scriptText(lldbExe));
+fs.writeFileSync(`${buildDir}/llnode.sh`, scriptText(lldbExe));
 
 // Exit with success.
 process.exit(0);
@@ -320,7 +320,7 @@ function scriptText(lldbExe) {
 
   return `#!/bin/sh
 
-LLNODE_SCRIPT=\`node -p "path.resolve('$0')"\`
+LLNODE_SCRIPT=\`node -p "require('path').resolve('$0')"\`
 
 SCRIPT_PATH=\`dirname $LLNODE_SCRIPT\`
 if [ \`basename $SCRIPT_PATH\` = ".bin" ]; then

--- a/scripts/llnode.sh
+++ b/scripts/llnode.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "Place holder script for llnode"
-
-exit 1;


### PR DESCRIPTION
Otherwise running `npm link` would always result in unstaged
changes. npm should be able to link the script after installation
is complete and the script has been generated in the module
directory.

Also requires the path module in the generated script so it works
in v4.x.