### PR TITLE
findrefs: refactor ::PrintRefs template strings

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -611,8 +611,8 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     if (v.raw() != search_value_.raw()) continue;
 
     std::string type_name = js_obj.GetTypeName(err);
-    result.Printf("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n",
-                  js_obj.raw(), type_name.c_str(), i, search_value_.raw());
+    result.Printf(array_reference_template().c_str(), js_obj.raw(),
+                  type_name.c_str(), i, search_value_.raw());
   }
 
   // Walk all the properties in this object.
@@ -627,7 +627,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     if (v.raw() == search_value_.raw()) {
       std::string key = entry.first.ToString(err);
       std::string type_name = js_obj.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", js_obj.raw(),
+      result.Printf(property_reference_template().c_str(), js_obj.raw(),
                     type_name.c_str(), key.c_str(), search_value_.raw());
     }
   }
@@ -642,13 +642,12 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
 
   // Concatenated and sliced strings refer to other strings so
   // we need to check their references.
-
   if (repr == v8->string()->kSlicedStringTag) {
     v8::SlicedString sliced_str(str);
     v8::String parent = sliced_str.Parent(err);
     if (err.Success() && parent.raw() == search_value_.raw()) {
       std::string type_name = sliced_str.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+      result.Printf(property_reference_template().c_str(), str.raw(),
                     type_name.c_str(), "<Parent>", search_value_.raw());
     }
   } else if (repr == v8->string()->kConsStringTag) {
@@ -657,14 +656,14 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::String first = cons_str.First(err);
     if (err.Success() && first.raw() == search_value_.raw()) {
       std::string type_name = cons_str.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+      result.Printf(property_reference_template().c_str(), str.raw(),
                     type_name.c_str(), "<First>", search_value_.raw());
     }
 
     v8::String second = cons_str.Second(err);
     if (err.Success() && second.raw() == search_value_.raw()) {
       std::string type_name = cons_str.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+      result.Printf(property_reference_template().c_str(), str.raw(),
                     type_name.c_str(), "<Second>", search_value_.raw());
     }
   } else if (repr == v8->string()->kThinStringTag) {
@@ -672,7 +671,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::String actual = thin_str.Actual(err);
     if (err.Success() && actual.raw() == search_value_.raw()) {
       std::string type_name = thin_str.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", str.raw(),
+      result.Printf(property_reference_template().c_str(), str.raw(),
                     type_name.c_str(), "<Actual>", search_value_.raw());
     }
   }
@@ -794,7 +793,7 @@ void FindReferencesCmd::PropertyScanner::PrintRefs(
     }
     if (key == search_value_) {
       std::string type_name = js_obj.GetTypeName(err);
-      result.Printf("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n", js_obj.raw(),
+      result.Printf(property_reference_template().c_str(), js_obj.raw(),
                     type_name.c_str(), key.c_str(), entry.second.raw());
     }
   }

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -27,6 +27,19 @@ using lldb::SBValue;
 using lldb::eReturnStatusFailed;
 using lldb::eReturnStatusSuccessFinishResult;
 
+const char* const
+    FindReferencesCmd::ObjectScanner::property_reference_template =
+        "0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n";
+const char* const FindReferencesCmd::ObjectScanner::array_reference_template =
+    "0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n";
+
+
+const char* const
+    FindReferencesCmd::StringScanner::property_reference_template =
+        "0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n";
+const char* const FindReferencesCmd::StringScanner::array_reference_template =
+    "0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 " '%s'\n";
+
 bool FindObjectsCmd::DoExecute(SBDebugger d, char** cmd,
                                SBCommandReturnObject& result) {
   SBTarget target = d.GetSelectedTarget();
@@ -611,8 +624,8 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     if (v.raw() != search_value_.raw()) continue;
 
     std::string type_name = js_obj.GetTypeName(err);
-    result.Printf(array_reference_template().c_str(), js_obj.raw(),
-                  type_name.c_str(), i, search_value_.raw());
+    result.Printf(array_reference_template, js_obj.raw(), type_name.c_str(), i,
+                  search_value_.raw());
   }
 
   // Walk all the properties in this object.
@@ -627,7 +640,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     if (v.raw() == search_value_.raw()) {
       std::string key = entry.first.ToString(err);
       std::string type_name = js_obj.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), js_obj.raw(),
+      result.Printf(property_reference_template, js_obj.raw(),
                     type_name.c_str(), key.c_str(), search_value_.raw());
     }
   }
@@ -647,8 +660,8 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::String parent = sliced_str.Parent(err);
     if (err.Success() && parent.raw() == search_value_.raw()) {
       std::string type_name = sliced_str.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), str.raw(),
-                    type_name.c_str(), "<Parent>", search_value_.raw());
+      result.Printf(property_reference_template, str.raw(), type_name.c_str(),
+                    "<Parent>", search_value_.raw());
     }
   } else if (repr == v8->string()->kConsStringTag) {
     v8::ConsString cons_str(str);
@@ -656,23 +669,23 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     v8::String first = cons_str.First(err);
     if (err.Success() && first.raw() == search_value_.raw()) {
       std::string type_name = cons_str.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), str.raw(),
-                    type_name.c_str(), "<First>", search_value_.raw());
+      result.Printf(property_reference_template, str.raw(), type_name.c_str(),
+                    "<First>", search_value_.raw());
     }
 
     v8::String second = cons_str.Second(err);
     if (err.Success() && second.raw() == search_value_.raw()) {
       std::string type_name = cons_str.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), str.raw(),
-                    type_name.c_str(), "<Second>", search_value_.raw());
+      result.Printf(property_reference_template, str.raw(), type_name.c_str(),
+                    "<Second>", search_value_.raw());
     }
   } else if (repr == v8->string()->kThinStringTag) {
     v8::ThinString thin_str(str);
     v8::String actual = thin_str.Actual(err);
     if (err.Success() && actual.raw() == search_value_.raw()) {
       std::string type_name = thin_str.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), str.raw(),
-                    type_name.c_str(), "<Actual>", search_value_.raw());
+      result.Printf(property_reference_template, str.raw(), type_name.c_str(),
+                    "<Actual>", search_value_.raw());
     }
   }
   // Nothing to do for other kinds of string.
@@ -793,7 +806,7 @@ void FindReferencesCmd::PropertyScanner::PrintRefs(
     }
     if (key == search_value_) {
       std::string type_name = js_obj.GetTypeName(err);
-      result.Printf(property_reference_template().c_str(), js_obj.raw(),
+      result.Printf(property_reference_template, js_obj.raw(),
                     type_name.c_str(), key.c_str(), entry.second.raw());
     }
   }
@@ -1279,8 +1292,7 @@ bool LLScan::ScanHeapForObjects(lldb::SBTarget target,
   return true;
 }
 
-std::string
-FindJSObjectsVisitor::MapCacheEntry::GetTypeNameWithProperties(
+std::string FindJSObjectsVisitor::MapCacheEntry::GetTypeNameWithProperties(
     ShowArrayLength show_array_length, size_t max_properties) {
   std::string type_name_with_properties(type_name);
 
@@ -1305,8 +1317,7 @@ FindJSObjectsVisitor::MapCacheEntry::GetTypeNameWithProperties(
 
 bool FindJSObjectsVisitor::MapCacheEntry::Load(v8::Map map,
                                                v8::HeapObject heap_object,
-                                               v8::LLV8* llv8,
-                                               v8::Error& err) {
+                                               v8::LLV8* llv8, v8::Error& err) {
   // Check type first
   is_histogram = FindJSObjectsVisitor::IsAHistogramType(map, err);
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -85,6 +85,14 @@ class FindReferencesCmd : public CommandBase {
                            v8::JSObject& js_obj, v8::Error& err) {}
     virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                            v8::Error& err) {}
+
+    inline std::string property_reference_template() {
+      return std::string("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n");
+    }
+
+    inline std::string array_reference_template() {
+      return std::string("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n");
+    }
   };
 
   void PrintReferences(lldb::SBCommandReturnObject& result,
@@ -152,6 +160,14 @@ class FindReferencesCmd : public CommandBase {
                    v8::Error& err) override;
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                    v8::Error& err) override;
+
+    inline std::string property_reference_template() {
+      return std::string("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n");
+    }
+
+    inline std::string array_reference_template() {
+      return std::string("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 " '%s'\n");
+    }
 
    private:
     LLScan* llscan_;

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -86,13 +86,8 @@ class FindReferencesCmd : public CommandBase {
     virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                            v8::Error& err) {}
 
-    inline std::string property_reference_template() {
-      return std::string("0x%" PRIx64 ": %s.%s=0x%" PRIx64 "\n");
-    }
-
-    inline std::string array_reference_template() {
-      return std::string("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n");
-    }
+    static const char* const property_reference_template;
+    static const char* const array_reference_template;
   };
 
   void PrintReferences(lldb::SBCommandReturnObject& result,
@@ -161,13 +156,8 @@ class FindReferencesCmd : public CommandBase {
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                    v8::Error& err) override;
 
-    inline std::string property_reference_template() {
-      return std::string("0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n");
-    }
-
-    inline std::string array_reference_template() {
-      return std::string("0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 " '%s'\n");
-    }
+    static const char* const property_reference_template;
+    static const char* const array_reference_template;
 
    private:
     LLScan* llscan_;
@@ -273,8 +263,8 @@ class FindJSObjectsVisitor : MemoryVisitor {
         ShowArrayLength show_array_length = kShowArrayLength,
         size_t max_properties = 0);
 
-    bool Load(v8::Map map, v8::HeapObject heap_object,
-              v8::LLV8* llv8, v8::Error& err);
+    bool Load(v8::Map map, v8::HeapObject heap_object, v8::LLV8* llv8,
+              v8::Error& err);
   };
 
   static bool IsAHistogramType(v8::Map& map, v8::Error& err);

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -32,8 +32,8 @@ void Module::Assign(SBTarget target, Common* common) {
 
 
 template <typename T>
-T ReadSymbolFromTarget(SBTarget& target, SBAddress& start,
-                       const char* name, Error& err) {
+T ReadSymbolFromTarget(SBTarget& target, SBAddress& start, const char* name,
+                       Error& err) {
   SBError sberr;
   T res = 0;
   target.ReadMemory(start, &res, sizeof(T), sberr);


### PR DESCRIPTION
I noticed that we have only a few template strings used in all PrintRefs, and they were repeating multiple times in the code.