### PR TITLE
test: more consistent test for findjsobjects -d

### DIFF
--- a/test/scan-test.js
+++ b/test/scan-test.js
@@ -37,7 +37,7 @@ function test(executable, core, t) {
 
   sess.linesUntil(versionMark, (err, lines) => {
     t.error(err);
-    t.ok(/\d+ Zlib/.test(lines.join('\n')), 'Zlib should be in findjsobjects');
+    t.ok(/\d+ Class/.test(lines.join('\n')), 'Class should be in findjsobjects');
 
     sess.send('v8 findjsobjects -d');
     // Just a separator
@@ -46,9 +46,8 @@ function test(executable, core, t) {
 
   sess.linesUntil(versionMark, (err, lines) => {
     t.error(err);
-    t.ok(/0 +0 Zlib/.test(lines.join('\n')), 'Zlib should be in findjsobjects -d');
-    t.ok(/1 +0 Zlib: onerror/.test(lines.join('\n')),
-         '"Zlib: onerror" should be in findjsobjects -d');
+    t.ok(/3 +0 Class: x, y, hashmap/.test(lines.join('\n')),
+         '"Class: x, y, hashmap" should be in findjsobjects -d');
 
     sess.send('v8 findjsinstances Zlib');
     // Just a separator


### PR DESCRIPTION
findjsobjects -d test relies on how the hidden-class it tests is built.
Zlib is a builtin from Node.js, therefore we cannot be sure about the
order attributes are assigned to the class, making its hidden-class
unpredictable. Using a class from our fixtures (in this case, Class)
makes the test more predictable across Node.js versions and across
multiple Operating Systems.

Ref: https://github.com/nodejs/llnode/pull/186