### PR TITLE
travis: increase versions and OS coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,82 @@
 language: node_js
-sudo: required
-dist: trusty
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
-node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "9"
+matrix:
+  include:
+    # Test on Ubuntu Trusty
+    - sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      node_js: "6"
+    - sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      node_js: "8"
+    - sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      node_js: "9"
+    - sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      node_js: "10"
+    # Test Node.js master nightly build
+    - node_js: "node"
+      sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      install:
+        - npm install --nodedir=$(dirname $(dirname $(which node)))/include/node
+      env:
+        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+        - NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+    # Test Node.js v8-canary nightly build
+    - node_js: "node"
+      sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
+      install:
+        - npm install --nodedir=$(dirname $(dirname $(which node)))/include/node
+      env:
+        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
+        - NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
+    # Test on OS X
+    - os: osx
+      osx_image: xcode9.3
+      node_js: "6"
+    - os: osx
+      osx_image: xcode9.3
+      node_js: "8"
+    - os: osx
+      osx_image: xcode9.3
+      node_js: "9"
+    - os: osx
+      osx_image: xcode9.3
+      node_js: "10"
+  allow_failures:
+    # Allow the nightly installs to fail
+    - node_js: "node"
+      sudo: required
+      dist: trusty
+      env:
+        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+        - NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+    - node_js: "node"
+      sudo: required
+      dist: trusty
+      env:
+        - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
+        - NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,6 @@ plugin: configure
 .PHONY: _travis
 _travis:
 	TEST_LLDB_BINARY="$(TEST_LLDB_BINARY)" \
-	TEST_LLNODE_DEBUG=true \
-	LLNODE_DEBUG=true \
 	npm test
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 [![npm](https://img.shields.io/npm/v/llnode.svg?style=flat-square)](https://npmjs.org/package/llnode)
-[![Build Status](https://img.shields.io/travis/nodejs/llnode.svg?style=flat-square)](https://travis-ci.org/nodejs/llnode)
+
 
 Node.js v4.x+ C++ plugin for the [LLDB](http://lldb.llvm.org) debugger.
 
@@ -21,7 +21,18 @@ with Node.js processes or core dumps in LLDB.
 
 https://asciinema.org/a/29589
 
-### Quick start
+## Build Status
+
+| Version | v6.x                    | v8.x                    | v9.x                    | v10.x                     | master                        | v8-canary                        |
+|---------|-------------------------|-------------------------|-------------------------|---------------------------|-------------------------------|----------------------------------|
+| **Trusty**  | [![v6.x badge][v6-trusty-badge]][travis] | [![v8.x badge][v8-trusty-badge]][travis] | [![v9.x badge][v9-trusty-badge]][travis] | [![v10.x badge][v10-trusty-badge]][travis] | [![master badge][master-trusty-badge]][travis] | [![v8-canary badge][canary-trusty-badge]][travis] |
+| **OS X**  | [![v6.x badge][v6-osx-badge]][travis] | [![v8.x badge][v8-osx-badge]][travis] | [![v9.x badge][v9-osx-badge]][travis] | [![v10.x badge][v10-osx-badge]][travis] | - | - |
+
+We have nightly test runs against all Node.js active release lines. We also test
+against Node.js master and Node.js v8-canary nightly builds to help us identify
+breaking changes on Node.js and V8 before they land on an active release line.
+
+## Quick start
 
 Start an LLDB session with the llnode plugin automatically loaded:
 
@@ -331,3 +342,17 @@ NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[travis]: https://travis-ci.org/nodejs/llnode
+[v6-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/1
+[v8-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/2
+[v9-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/3
+[v10-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/4
+
+[v6-osx-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/5
+[v8-osx-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/6
+[v9-osx-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/7
+[v10-osx-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/8
+
+[master-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/9
+[canary-trusty-badge]: https://travis-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/10

--- a/test/common.js
+++ b/test/common.js
@@ -31,8 +31,8 @@ else
   pluginName = 'llnode.so';
 
 exports.llnodePath = path.join(exports.projectDir, pluginName);
-exports.saveCoreTimeout = 180 * 1000;
-exports.loadCoreTimeout = 20 * 1000;
+exports.saveCoreTimeout = 360 * 1000;
+exports.loadCoreTimeout = 60 * 1000;
 exports.versionMark = /^lldb-|^lldb version/;
 
 function SessionOutput(session, stream, timeout) {


### PR DESCRIPTION
* Reworked travis.yaml to use matrix settings, giving us more control
  over each job settings.
* Remove v4.x, since it's not a supported release line anymore
* Add jobs v10.x
* Add jobs for Mac OS X
* Add jobs for Node.js master and v8-canary builds. Those jobs are
  ignored in the build final result.
* Add a build status table to the README

Ref: https://github.com/nodejs/llnode/issues/187