### PR TITLE
src: fix object inspection for V8 6.4

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -209,6 +209,7 @@ void Map::Load() {
         "char");
   }
 
+  kInstanceTypeOffset = LoadConstant("class_Map__instance_type__uint16_t");
   kInstanceSizeOffset = LoadConstant("class_Map__instance_size__int",
                                      "class_Map__instance_size_in_words__char");
   kDictionaryMapShift = LoadConstant("bit_field3_dictionary_map_shift",
@@ -574,6 +575,8 @@ void Frame::Load() {
 
 void Types::Load() {
   kFirstNonstringType = LoadConstant("FirstNonstringType");
+  kFirstJSObjectType =
+      LoadConstant("type_JSGlobalObject__JS_GLOBAL_OBJECT_TYPE");
 
   kHeapNumberType = LoadConstant("type_HeapNumber__HEAP_NUMBER_TYPE");
   kMapType = LoadConstant("type_Map__MAP_TYPE");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -204,7 +204,7 @@ void Map::Load() {
       "class_Map__inobject_properties_or_constructor_function_index__int",
       "class_Map__inobject_properties__int");
   if (kInObjectPropertiesOffset == -1) {
-    kInObjectPropertiesOffset = LoadConstant(
+    kInObjectPropertiesStartOffset = LoadConstant(
         "class_Map__inobject_properties_start_or_constructor_function_index__"
         "char");
   }

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -94,6 +94,7 @@ class Map : public Module {
   int64_t kInstanceDescriptorsOffset;
   int64_t kBitField3Offset;
   int64_t kInObjectPropertiesOffset;
+  int64_t kInObjectPropertiesStartOffset;
   int64_t kInstanceSizeOffset;
 
   int64_t kNumberOfOwnDescriptorsMask;

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -96,6 +96,7 @@ class Map : public Module {
   int64_t kInObjectPropertiesOffset;
   int64_t kInObjectPropertiesStartOffset;
   int64_t kInstanceSizeOffset;
+  int64_t kInstanceTypeOffset;
 
   int64_t kNumberOfOwnDescriptorsMask;
   int64_t kNumberOfOwnDescriptorsShift;
@@ -480,6 +481,7 @@ class Types : public Module {
   MODULE_DEFAULT_METHODS(Types);
 
   int64_t kFirstNonstringType;
+  int64_t kFirstJSObjectType;
 
   int64_t kHeapNumberType;
   int64_t kMapType;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -159,7 +159,21 @@ inline int64_t Map::BitField3(Error& err) {
   return v8()->LoadUnsigned(LeaField(v8()->map()->kBitField3Offset), 4, err);
 }
 
+inline int64_t Map::InstanceType(Error& err) {
+  return v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceTypeOffset), 2, err);
+}
+
+inline bool Map::IsJSObjectMap(Error& err) {
+  return InstanceType(err) >= v8()->types()->kFirstJSObjectType;
+}
+
+
 inline int64_t Map::InObjectProperties(Error& err) {
+  if (!IsJSObjectMap(err)) {
+    err = Error::Failure(
+        "Invalid call to Map::InObjectProperties with a non-JsObject type");
+    return 0;
+  }
   if (v8()->map()->kInObjectPropertiesOffset != -1) {
     return LoadField(v8()->map()->kInObjectPropertiesOffset, err) & 0xff;
   } else {
@@ -169,11 +183,19 @@ inline int64_t Map::InObjectProperties(Error& err) {
     // changes to a minimum on llnode and to comply with V8, we're using the
     // same implementation from
     // https://chromium-review.googlesource.com/c/v8/v8/+/776720/9/src/objects-inl.h#3027.
-    int64_t in_objects_start =
+    int64_t in_object_properties_start_offset =
         LoadField(v8()->map()->kInObjectPropertiesStartOffset, err) & 0xff;
-    return v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceSizeOffset), 1,
-                              err) -
-           in_objects_start;
+    int64_t instance_size =
+        v8()->LoadUnsigned(LeaField(v8()->map()->kInstanceSizeOffset), 1, err);
+    return instance_size - in_object_properties_start_offset;
+  }
+}
+
+inline int64_t Map::ConstructorFunctionIndex(Error& err) {
+  if (v8()->map()->kInObjectPropertiesOffset != -1) {
+    return LoadField(v8()->map()->kInObjectPropertiesOffset, err) & 0xff;
+  } else {
+    return LoadField(v8()->map()->kInObjectPropertiesStartOffset, err) & 0xff;
   }
 }
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1278,7 +1278,16 @@ std::string Map::Inspect(InspectOptions* options, Error& err) {
   int64_t own_descriptors_count = NumberOfOwnDescriptors(err);
   if (err.Fail()) return std::string();
 
-  int64_t in_object_properties = InObjectProperties(err);
+  std::string in_object_properties_or_constructor;
+  int64_t in_object_properties_or_constructor_index;
+  if (IsJSObjectMap(err)) {
+    if (err.Fail()) return std::string();
+    in_object_properties_or_constructor_index = InObjectProperties(err);
+    in_object_properties_or_constructor = std::string("in_object_size");
+  } else {
+    in_object_properties_or_constructor_index = ConstructorFunctionIndex(err);
+    in_object_properties_or_constructor = std::string("constructor_index");
+  }
   if (err.Fail()) return std::string();
 
   int64_t instance_size = InstanceSize(err);
@@ -1286,10 +1295,11 @@ std::string Map::Inspect(InspectOptions* options, Error& err) {
 
   char tmp[256];
   snprintf(tmp, sizeof(tmp),
-           "<Map own_descriptors=%d in_object=%d instance_size=%d "
+           "<Map own_descriptors=%d %s=%d instance_size=%d "
            "descriptors=0x%016" PRIx64,
            static_cast<int>(own_descriptors_count),
-           static_cast<int>(in_object_properties),
+           in_object_properties_or_constructor.c_str(),
+           static_cast<int>(in_object_properties_or_constructor_index),
            static_cast<int>(instance_size), descriptors_obj.raw());
   if (!options->detailed) {
     return std::string(tmp) + ">";

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -137,9 +137,12 @@ class Map : public HeapObject {
   inline HeapObject InstanceDescriptors(Error& err);
   inline int64_t BitField3(Error& err);
   inline int64_t InObjectProperties(Error& err);
+  inline int64_t ConstructorFunctionIndex(Error& err);
   inline int64_t InstanceSize(Error& err);
+  inline int64_t InstanceType(Error& err);
 
   inline bool IsDictionary(Error& err);
+  inline bool IsJSObjectMap(Error& err);
   inline int64_t NumberOfOwnDescriptors(Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);


### PR DESCRIPTION
V8 6.4 "replaces the in-object properties count byte in the map
with the byte that stores the start offset of in-object properties".
Object inspection on llnode relies on in-object properties being count
bytes, so these are minimal changes to make object inspection work again
with V8 6.4 while keeping compatibility with previous versions.

Ref: https://chromium-review.googlesource.com/c/v8/v8/+/776720
Fixes: https://github.com/nodejs/llnode/issues/158