### PR TITLE
[WIP] src: `v8 snapshot` command

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -2,6 +2,8 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sstream>
+#include <fstream>
 
 #include <cinttypes>
 
@@ -396,6 +398,9 @@ bool PluginInitialize(SBDebugger d) {
       " * -s, --string string  - all properties that refer to the specified "
       "JavaScript string value\n"
       "\n");
+
+  v8.AddCommand("snapshot", new llnode::V8SnapshotCmd(),
+              "Converts the core file being debugged into a V8 snapshot\n");
 
   return true;
 }

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -103,6 +103,7 @@ class V8SnapshotCmd : public CommandBase {
   Node::Type GetInstanceType(v8::Error &err, uint64_t word);
   uint64_t GetStringId(v8::Error &err, std::string name);
   uint64_t GetSelfSize(v8::Error &err, uint64_t word);
+  Edge CreateEdgeFromValue(v8::Error &err, v8::HeapObject &obj, v8::Value value);
   uint64_t ChildrenCount(v8::Error &err, uint64_t word);
 
   bool SerializeImpl(v8::Error &err);

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -45,20 +45,75 @@ class ListCmd : public CommandBase {
 
 class V8SnapshotCmd : public CommandBase {
  public:
+  struct Node {
+    enum Type {
+    kHidden = 0,  // v8::HeapGraphNode::kHidden,
+      kArray = 1,  // v8::HeapGraphNode::kArray,
+      kString = 2,  // v8::HeapGraphNode::kString,
+      kObject = 3,  // v8::HeapGraphNode::kObject,
+      kCode = 4,  // v8::HeapGraphNode::kCode,
+    kClosure = 5,  // v8::HeapGraphNode::kClosure,
+      kRegExp = 6,  //v8::HeapGraphNode::kRegExp,
+      kHeapNumber = 7,  // v8::HeapGraphNode::kHeapNumber,
+    kNative = 8,  // v8::HeapGraphNode::kNative,
+    kSynthetic = 9,  // v8::HeapGraphNode::kSynthetic,
+    kConsString = 10,  // v8::HeapGraphNode::kConsString,
+    kSlicedString = 11,  // v8::HeapGraphNode::kSlicedString,
+    kSymbol = 12,  // v8::HeapGraphNode::kSymbol,
+      kSimdValue = 13,  // v8::HeapGraphNode::kSimdValue
+
+      kInvalid = -1
+    };
+    // static const int kNoEntry;
+
+    uint64_t addr;
+    Type type;
+    uint64_t name_id;
+    uint64_t node_id;
+    uint64_t self_size;
+    uint64_t children;
+    uint64_t trace_node_id;
+  };
+
+  struct Edge {
+    // TODO (mmarchini) this should come from V8 metadata
+    enum Type {
+      kContextVariable = 0, // v8::HeapGraphEdge::kContextVariable,
+      kElement = 1, // v8::HeapGraphEdge::kElement,
+      kProperty = 2, // v8::HeapGraphEdge::kProperty,
+      kInternal = 3, // v8::HeapGraphEdge::kInternal,
+      kHidden = 4, // v8::HeapGraphEdge::kHidden,
+      kShortcut = 5, // v8::HeapGraphEdge::kShortcut,
+      kWeak = 6 // v8::HeapGraphEdge::kWeak
+    };
+
+    Type type;
+    uint64_t index_or_property;
+    uint64_t to_id;
+    uint64_t to_addr;
+  };
+
   ~V8SnapshotCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
+
+  void PrepareData(v8::Error &err);
+
+  Node::Type GetInstanceType(v8::Error &err, uint64_t word);
+  uint64_t GetStringId(v8::Error &err, std::string name);
+  uint64_t GetSelfSize(v8::Error &err, uint64_t word);
+  uint64_t ChildrenCount(v8::Error &err, uint64_t word);
 
   bool SerializeImpl(v8::Error &err);
 
   void SerializeSnapshot(v8::Error &err);
 
   void SerializeNodes(v8::Error &err);
-  void SerializeNode(v8::Error &err, bool first_node);
+  void SerializeNode(v8::Error &err, Node* node, bool first_node);
 
   void SerializeEdges(v8::Error &err);
-  void SerializeEdge(v8::Error &err, bool first_edge);
+  void SerializeEdge(v8::Error &err, Edge edge, bool first_edge);
 
   // TODO
   void SerializeTraceNodeInfos(v8::Error &err);
@@ -72,10 +127,13 @@ class V8SnapshotCmd : public CommandBase {
 
   // TODO
   void SerializeStrings(v8::Error &err);
-  void SerializeString(v8::Error &err, const char* s);
+  void SerializeString(v8::Error &err, std::string s);
 
  private:
   std::ofstream writer_;
+  std::vector<Node> nodes_;
+  std::vector<Edge> edges_;
+  std::vector<std::string> strings_;
 };
 
 }  // namespace llnode

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -72,6 +72,7 @@ class V8SnapshotCmd : public CommandBase {
 
   // TODO
   void SerializeStrings(v8::Error &err);
+  void SerializeString(v8::Error &err, const char* s);
 
  private:
   std::ofstream writer_;

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -43,6 +43,40 @@ class ListCmd : public CommandBase {
                  lldb::SBCommandReturnObject& result) override;
 };
 
+class V8SnapshotCmd : public CommandBase {
+ public:
+  ~V8SnapshotCmd() override {}
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+  bool SerializeImpl(v8::Error &err);
+
+  void SerializeSnapshot(v8::Error &err);
+
+  void SerializeNodes(v8::Error &err);
+  void SerializeNode(v8::Error &err, bool first_node);
+
+  void SerializeEdges(v8::Error &err);
+  void SerializeEdge(v8::Error &err, bool first_edge);
+
+  // TODO
+  void SerializeTraceNodeInfos(v8::Error &err);
+
+  // TODO
+  void SerializeTraceTree(v8::Error &err);
+  void SerializeTraceNode(v8::Error &err);
+
+  // TODO
+  void SerializeSamples(v8::Error &err);
+
+  // TODO
+  void SerializeStrings(v8::Error &err);
+
+ private:
+  std::ofstream writer_;
+};
+
 }  // namespace llnode
 
 #endif  // SRC_LLNODE_H_

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1108,17 +1108,17 @@ bool V8SnapshotCmd::SerializeImpl(v8::Error &err) {
   if (err.Fail()) return false;
   writer_ << "]," << std::endl;
   writer_ << "\"trace_tree\":[";
-  // SerializeTraceTree(err);  // TODO incomplete
+  SerializeTraceTree(err);  // TODO incomplete
   if (err.Fail()) return false;
   writer_ << "]," << std::endl;
 
   writer_ << "\"samples\":[";
-  // SerializeSamples(err);  // TODO incomplete
+  SerializeSamples(err);  // TODO incomplete
   if (err.Fail()) return false;
   writer_ << "]," << std::endl;
 
   writer_ << "\"strings\":[";
-  // SerializeStrings(err);  // TODO incomplete
+  SerializeStrings(err);  // TODO incomplete
   if (err.Fail()) return false;
   writer_ << "]";
   writer_ << "}";
@@ -1292,6 +1292,132 @@ void V8SnapshotCmd::SerializeTraceNodeInfos(v8::Error &err) {
     writer_ << function_id << "," << name << "," << script_name << "," <<
         script_id << "," << line << "," << column << std::endl;
   }
+}
+
+
+void V8SnapshotCmd::SerializeTraceTree(v8::Error &err) {
+  // AllocationTracker* tracker = snapshot_->profiler()->allocation_tracker();
+  // if (!tracker) return;
+  // AllocationTraceTree* traces = tracker->trace_tree();
+  SerializeTraceNode(err);
+}
+
+
+// void HeapSnapshotJSONSerializer::SerializeTraceNode(AllocationTraceNode* node) {
+void V8SnapshotCmd::SerializeTraceNode(v8::Error &err) {
+  auto node_id = 0;  // node->id()
+  auto node_function_info_index = 0;  // node->function_info_index()
+  auto node_allocation_count = 0;  // node->allocation_count()
+  auto node_allocation_size = 0;  // node->allocation_size()
+
+  writer_ << node_id << "," << node_function_info_index << ","
+      << node_allocation_count << "," << node_allocation_size << "," << "[";
+
+
+  // int i = 0;
+  // for (AllocationTraceNode* child : node->children()) {
+  //   if (i++ > 0) {
+  //     writer_->AddCharacter(',');
+  //   }
+  //   SerializeTraceNode(child);
+  // }
+  writer_ << ']';
+}
+
+
+void V8SnapshotCmd::SerializeSamples(v8::Error &err) {
+  // const std::vector<HeapObjectsMap::TimeInterval>& samples =
+  //     snapshot_->profiler()->heap_object_map()->samples();
+  // if (samples.empty()) return;
+  // base::TimeTicks start_time = samples[0].timestamp;
+  // // The buffer needs space for 2 unsigned ints, 2 commas, \n and \0
+  // const int kBufferSize = MaxDecimalDigitsIn<sizeof(
+  //                             base::TimeDelta().InMicroseconds())>::kUnsigned +
+  //                         MaxDecimalDigitsIn<sizeof(samples[0].id)>::kUnsigned +
+  //                         2 + 1 + 1;
+  // EmbeddedVector<char, kBufferSize> buffer;
+  int i = 0;
+  // for (const HeapObjectsMap::TimeInterval& sample : samples) {
+  for (auto it : {1, 2, 3}) {
+    if (i++ > 0) {
+      writer_ << ',';
+    }
+
+    auto time_delta = 0;  // time_delta.InMicroseconds()
+    auto sample_last_assigned_id = 0;  // sample.last_assigned_id()
+
+    writer_ << time_delta << "," << sample_last_assigned_id << std::endl;
+  }
+}
+
+
+void V8SnapshotCmd::SerializeStrings(v8::Error &err) {
+  std::vector<std::string> sorted_strings;
+  sorted_strings.push_back("lala");
+  sorted_strings.push_back("lele");
+  sorted_strings.push_back("lili");
+  // for (base::HashMap::Entry* entry = strings_.Start(); entry != NULL;
+  //      entry = strings_.Next(entry)) {
+  //   int index = static_cast<int>(reinterpret_cast<uintptr_t>(entry->value));
+  //   sorted_strings[index] = reinterpret_cast<const unsigned char*>(entry->key);
+  // }
+  writer_ << "\"<dummy>\"";
+  for (auto s : sorted_strings) {
+    writer_ << ',';
+    SerializeString(err, s.c_str());
+    if (err.Fail()) return;
+  }
+}
+
+
+void V8SnapshotCmd::SerializeString(v8::Error &err, const char* s) {
+  writer_ << '\n';
+  writer_ << '\"';
+  std::cout << "string: " << s << std::endl;
+  for ( ; *s != '\0'; ++s) {
+    switch (*s) {
+      case '\b':
+        writer_ << "\\b";
+        continue;
+      case '\f':
+        writer_ << "\\f";
+        continue;
+      case '\n':
+        writer_ << "\\n";
+        continue;
+      case '\r':
+        writer_ << "\\r";
+        continue;
+      case '\t':
+        writer_ << "\\t";
+        continue;
+      case '\"':
+      case '\\':
+        writer_ << '\\';
+        writer_ << *s;
+        continue;
+      default:
+        if (*s > 31 && *s < 128) {
+          writer_ << *s;
+        // } else if (*s <= 31) {
+        //   // Special character with no dedicated literal.
+        //   WriteUChar(writer_, *s);
+        // } else {
+        //   // Convert UTF-8 into \u UTF-16 literal.
+        //   size_t length = 1, cursor = 0;
+        //   for ( ; length <= 4 && *(s + length) != '\0'; ++length) { }
+        //   unibrow::uchar c = unibrow::Utf8::CalculateValue(s, length, &cursor);
+        //   if (c != unibrow::Utf8::kBadChar) {
+        //     WriteUChar(writer_, c);
+        //     DCHECK(cursor != 0);
+        //     s += cursor - 1;
+        //   } else {
+        //     writer_->AddCharacter('?');
+        //   }
+        }
+    }
+  }
+  writer_ << '\"';
 }
 
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1083,16 +1083,22 @@ bool V8SnapshotCmd::DoExecute(SBDebugger d, char** cmd,
     return false;
   }
 
+
   PrepareData(err);
   if (err.Fail()) {
-    std::cout << "wow" << std::endl;
+    result.Printf("Error while generating snapshot\n");
+    writer_.close();
     return false;
   }
 
   SerializeImpl(err);
   if (err.Fail()) {
-    std::cout << "WOW" << std::endl;
+    result.Printf("Error while generating snapshot\n");
+    writer_.close();
+    return false;
   }
+
+  result.Printf("Snapshot generated at ./core.heapsnapshot\n");
 
   writer_.close();
   return !err.Fail();
@@ -1432,7 +1438,7 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
   for(auto type_record : llscan.GetMapsToInstances()) {
     for(auto instance : type_record.second->GetInstances()) {
       if (visited.count(instance) != 0) {
-        std::cout << "bad" << std::endl;
+        // std::cout << "bad" << std::endl;
         return;
       }
 
@@ -1440,7 +1446,7 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
       node.addr = instance;
       node.type = GetInstanceType(err, instance);
       if(node.type == Node::Type::kInvalid) {
-        std::cout << "kInvalid: " << instance << std::endl;
+        // std::cout << "kInvalid: " << instance << std::endl;
         continue;
       }
       node.name_id = GetStringId(err, type_record.second->GetTypeName());
@@ -1449,7 +1455,7 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
       node.self_size = GetSelfSize(err, instance);
       node.children = ChildrenCount(err, instance);
       if (node.children == -1) {
-        std::cout << "-1 children: " << instance << std::endl;
+        // std::cout << "-1 children: " << instance << std::endl;
         continue;
       }
       node.trace_node_id = 0;  // TODO (mmarchini) traces
@@ -1460,11 +1466,11 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
   }
 
   int problems = 0;
-  std::cout << edges_.size() << std::endl;
+  // std::cout << edges_.size() << std::endl;
   // Prepare Edges
   for(auto& edge : edges_) {
     if (visited.count(edge.to_addr) != 1) {
-      std::cout << "Edge was not visited: " << std::hex << edge.to_addr << std::endl;
+      // std::cout << "Edge was not visited: " << std::hex << edge.to_addr << std::endl;
       edge.to_id = -1;
       problems++;
       continue;
@@ -1472,8 +1478,8 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
     Node node = visited.at(edge.to_addr);
 
     if (node.addr != edge.to_addr) {
-      std::cout << "Invalid edge: " << std::hex << edge.to_addr << " != ";
-      std::cout << std::hex << node.addr << std::endl;
+      // std::cout << "Invalid edge: " << std::hex << edge.to_addr << " != ";
+      // std::cout << std::hex << node.addr << std::endl;
       edge.to_id = -1;
       problems++;
       continue;
@@ -1481,7 +1487,7 @@ void V8SnapshotCmd::PrepareData(v8::Error &err) {
     // std::cout << "worked" << std::endl;
     edge.to_id = node.node_id * 6;
   }
-  std::cout << "Problems found: " << std::dec << problems << std::endl;
+  // std::cout << "Problems found: " << std::dec << problems << std::endl;
 }
 
 

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -73,7 +73,7 @@ class FindReferencesCmd : public CommandBase {
   void PrintReferences(lldb::SBCommandReturnObject& result,
                        ReferencesVector* references, ObjectScanner* scanner);
 
-  void ScanForReferences(ObjectScanner* scanner);
+  static void ScanForReferences(ObjectScanner* scanner);
 
   class ReferenceScanner : public ObjectScanner {
    public:

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -474,21 +474,21 @@ class Types : public Module {
 
   int64_t kFirstNonstringType;
 
-  int64_t kHeapNumberType;
+  int64_t kHeapNumberType;  //
   int64_t kMapType;
   int64_t kGlobalObjectType;
   int64_t kGlobalProxyType;
   int64_t kOddballType;
-  int64_t kJSObjectType;
-  int64_t kJSAPIObjectType;
-  int64_t kJSSpecialAPIObjectType;
-  int64_t kJSArrayType;
-  int64_t kCodeType;
+  int64_t kJSObjectType;  //
+  int64_t kJSAPIObjectType;  //
+  int64_t kJSSpecialAPIObjectType;  //
+  int64_t kJSArrayType;  //
+  int64_t kCodeType;  //
   int64_t kJSFunctionType;
-  int64_t kFixedArrayType;
-  int64_t kJSArrayBufferType;
-  int64_t kJSTypedArrayType;
-  int64_t kJSRegExpType;
+  int64_t kFixedArrayType;  //
+  int64_t kJSArrayBufferType;  //
+  int64_t kJSTypedArrayType;  //
+  int64_t kJSRegExpType;  //
   int64_t kJSDateType;
   int64_t kSharedFunctionInfoType;
   int64_t kScriptType;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -12,6 +12,7 @@ namespace llnode {
 
 class FindJSObjectsVisitor;
 class FindReferencesCmd;
+class V8SnapshotCmd;
 
 namespace v8 {
 
@@ -280,9 +281,9 @@ class JSObject : public HeapObject {
 
   static inline bool IsObjectType(LLV8* v8, int64_t type);
 
- protected:
   template <class T>
   T GetInObjectValue(int64_t size, int index, Error& err);
+ protected:
   void ElementKeys(std::vector<std::string>& keys, Error& err);
   void DictionaryKeys(std::vector<std::string>& keys, Error& err);
   void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
@@ -551,6 +552,7 @@ class LLV8 {
   friend class CodeMap;
   friend class llnode::FindJSObjectsVisitor;
   friend class llnode::FindReferencesCmd;
+  friend class llnode::V8SnapshotCmd;
 };
 
 #undef V8_VALUE_DEFAULT_METHODS


### PR DESCRIPTION
**DO NOT LAND YET**

[P.S.: The code is a mess right now, I'm opening a PR to get feedback on how the feature should look like]

This PR introduces a new command to create a V8 snapshot from a core dump. Right now the snapshot is not fully functional, but it works on Chrome DevTools. The goal is to enable the use of Chrome DevTools alongside llnode.

We still need to address https://github.com/nodejs/llnode/issues/195 and https://github.com/nodejs/llnode/issues/197 before making it work properly. Right now it can be used with the command `v8 snapshot`, which will create a `core.heapsnapshot` in the current working directory. The generated file can be open by Chrome DevTools, but it doesn't show a list of retainers yet.