### PR TITLE
src: fix backtrace for V8 6.7

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -128,6 +128,8 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
         result.Printf("  %c frame #%u: 0x%016" PRIx64 " %s\n", star, i, pc,
                       res.c_str());
         continue;
+      } else {
+        v8::Error::PrintInDebugMode("%s", err.GetMessage());
       }
     }
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -288,13 +288,14 @@ void JSDate::Load() {
 
 
 void SharedInfo::Load() {
+  kNameOrScopeInfoOffset =
+      LoadConstant("class_SharedFunctionInfo__name_or_scope_info__Object");
   kNameOffset = LoadConstant("class_SharedFunctionInfo__raw_name__Object",
                              "class_SharedFunctionInfo__name__Object");
   kInferredNameOffset =
       LoadConstant("class_SharedFunctionInfo__inferred_name__String",
                    "class_SharedFunctionInfo__function_identifier__Object");
   kScriptOffset = LoadConstant("class_SharedFunctionInfo__script__Object");
-  kCodeOffset = LoadConstant("class_SharedFunctionInfo__code__Code");
   kStartPositionOffset =
       LoadConstant("class_SharedFunctionInfo__start_position_and_type__int",
                    "class_SharedFunctionInfo__start_position_and_type__SMI");
@@ -323,7 +324,8 @@ void SharedInfo::Load() {
     kStartPositionMask = ~((1 << kStartPositionShift) - 1);
   }
 
-  if (LoadConstant("class_SharedFunctionInfo__compiler_hints__int") == -1)
+  if (LoadConstant("class_SharedFunctionInfo__compiler_hints__int") == -1 &&
+      kNameOrScopeInfoOffset == -1)
     kEndPositionShift = 1;
   else
     kEndPositionShift = 0;

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -173,10 +173,10 @@ class SharedInfo : public Module {
  public:
   MODULE_DEFAULT_METHODS(SharedInfo);
 
+  int64_t kNameOrScopeInfoOffset;
   int64_t kNameOffset;
   int64_t kInferredNameOffset;
   int64_t kScriptOffset;
-  int64_t kCodeOffset;
   int64_t kStartPositionOffset;
   int64_t kEndPositionOffset;
   int64_t kParameterCountOffset;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1093,7 +1093,9 @@ std::string FixedArray::InspectContents(int length, Error& err) {
 std::string Context::Inspect(Error& err) {
   std::string res;
   // Not enough postmortem information, return bare minimum
-  if (v8()->shared_info()->kScopeInfoOffset == -1) return res;
+  if (v8()->shared_info()->kScopeInfoOffset == -1 &&
+      v8()->shared_info()->kNameOrScopeInfoOffset == -1)
+    return res;
 
   Value previous = Previous(err);
   if (err.Fail()) return std::string();

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -159,6 +159,8 @@ class String : public HeapObject {
 
   std::string ToString(Error& err);
   std::string Inspect(InspectOptions* options, Error& err);
+
+  static inline bool IsString(LLV8* v8, HeapObject heap_object, Error& err);
 };
 
 class Script : public HeapObject {
@@ -191,7 +193,6 @@ class SharedFunctionInfo : public HeapObject {
   inline String Name(Error& err);
   inline Value InferredName(Error& err);
   inline Script GetScript(Error& err);
-  inline Code GetCode(Error& err);
   inline HeapObject GetScopeInfo(Error& err);
   inline int64_t ParameterCount(Error& err);
   inline int64_t StartPosition(Error& err);
@@ -200,6 +201,11 @@ class SharedFunctionInfo : public HeapObject {
   std::string ProperName(Error& err);
   std::string GetPostfix(Error& err);
   std::string ToString(Error& err);
+
+ private:
+  inline String name(Error& err);
+  inline HeapObject scope_info(Error& err);
+  inline HeapObject name_or_scope_info(Error& err);
 };
 
 class OneByteString : public String {
@@ -412,6 +418,7 @@ class ScopeInfo : public FixedArray {
 
   inline String ContextLocalName(int index, int param_count, int stack_count,
                                  Error& err);
+  inline HeapObject MaybeFunctionName(Error& err);
 };
 
 class Oddball : public HeapObject {


### PR DESCRIPTION
ETA: May 29th (or once https://github.com/nodejs/node/pull/19989/ lands)

V8 6.7 unifies SharedFunctionInfo::name and
SharedFunctionInfo::scope_info into
SharedFunctionInfo::name_or_scope_info. Because of that, the function's
name can be inferred either from name_or_scope_info (when it's a string)
or from ScopeInfo::FunctionName (when name_or_scope_info is a
ScopeInfo).

Also, SharedFunctionInfo::GetCode was removed because it wasn't being
used anywhere.

Ref: https://chromium-review.googlesource.com/964201
Fixes: https://github.com/nodejs/llnode/issues/180

#### TODO List

  - [x] Add comments explaining MaybeFunctionName