### PR TITLE
src: fix context inspection for V8 6.8

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -244,8 +244,9 @@ void ScopeInfo::Load() {
 
 
 void Context::Load() {
-  kClosureIndex =
-      LoadConstant("class_Context__closure_index__int", "context_idx_closure");
+  kClosureIndex = LoadConstant("class_Context__closure_index__int",
+                               "context_idx_closure", -1);
+  kScopeInfoIndex = LoadConstant("context_idx_scope_info", -1);
   kPreviousIndex =
       LoadConstant("class_Context__previous_index__int", "context_idx_prev");
   // TODO (mmarchini) change LoadConstant to accept variable arguments, a list

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -487,6 +487,9 @@ void Types::Load() {
   kFirstJSObjectType =
       LoadConstant("type_JSGlobalObject__JS_GLOBAL_OBJECT_TYPE");
 
+  kFirstContextType = LoadConstant("FirstContextType");
+  kLastContextType = LoadConstant("LastContextType");
+
   kHeapNumberType = LoadConstant("type_HeapNumber__HEAP_NUMBER_TYPE");
   kMapType = LoadConstant("type_Map__MAP_TYPE");
   kGlobalObjectType =
@@ -508,6 +511,7 @@ void Types::Load() {
   kSharedFunctionInfoType =
       LoadConstant("type_SharedFunctionInfo__SHARED_FUNCTION_INFO_TYPE");
   kScriptType = LoadConstant("type_Script__SCRIPT_TYPE");
+  kScopeInfoType = LoadConstant("type_ScopeInfo__SCOPE_INFO_TYPE");
 
   if (kJSAPIObjectType == -1) {
     common_->Load();

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -206,6 +206,15 @@ class Context : public Module {
   int64_t kEmbedderDataIndex;
   int64_t kMinContextSlots;
 
+  inline bool hasClosure() {
+    // NOTE (mmarchini): V8 6.8 replaced the closure field (which was a
+    // JSFunction) with a scope_info field (which is a ScopeInfo). The change
+    // made it easier to get the scope info for a context, but removed our
+    // ability to get the outer function for a given context. We can still get
+    // the outer context through the previous field though.
+    return kClosureIndex != -1;
+  }
+
  protected:
   void Load();
 };

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -466,6 +466,9 @@ class Types : public Module {
   int64_t kFirstNonstringType;
   int64_t kFirstJSObjectType;
 
+  int64_t kFirstContextType;
+  int64_t kLastContextType;
+
   int64_t kHeapNumberType;
   int64_t kMapType;
   int64_t kGlobalObjectType;
@@ -484,6 +487,7 @@ class Types : public Module {
   int64_t kJSDateType;
   int64_t kSharedFunctionInfoType;
   int64_t kScriptType;
+  int64_t kScopeInfoType;
 
  protected:
   void Load();

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -199,6 +199,7 @@ class Context : public Module {
   CONSTANTS_DEFAULT_METHODS(Context);
 
   int64_t kClosureIndex;
+  int64_t kScopeInfoIndex;
   int64_t kGlobalObjectIndex;
   int64_t kPreviousIndex;
   int64_t kNativeIndex;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1103,7 +1103,7 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
   HeapObject heap_previous = HeapObject(previous);
   if (heap_previous.Check()) {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(previous)=0x%016" PRIx64).c_str(), previous.raw());
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(previous)=0x%016" PRIx64).c_str(), previous.raw());
     res += std::string(tmp) + ":<Context>,";
   }
 
@@ -1113,7 +1113,7 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
     JSFunction closure = Closure(err);
     if (err.Fail()) return std::string();
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(closure)=0x%016" PRIx64 " {").c_str(),
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(closure)=0x%016" PRIx64 " {").c_str(),
              closure.raw());
     res += tmp;
 
@@ -1122,7 +1122,7 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
     if (err.Fail()) return std::string();
   } else {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(scope_info)=0x%016" PRIx64).c_str(),
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(scope_info)=0x%016" PRIx64).c_str(),
              scope.raw());
 
     res += std::string(tmp) + ":<ScopeInfo";
@@ -1146,7 +1146,7 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
 
     if (!res.empty()) res += ",\n";
 
-    res += options->get_indent_spaecs() + name.ToString(err) + "=";
+    res += options->get_indent_spaces() + name.ToString(err) + "=";
     if (err.Fail()) return std::string();
 
     Value value = ContextSlot(i, err);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -392,7 +392,7 @@ std::string JSFunction::Inspect(InspectOptions* options, Error& err) {
     std::string context_str = context.Inspect(err);
     if (err.Fail()) return std::string();
 
-    if (!context_str.empty()) res += "{\n" + context_str + "}";
+    if (!context_str.empty()) res += ":" + context_str;
 
     if (options->print_source) {
       SharedFunctionInfo info = Info(err);
@@ -1061,11 +1061,12 @@ HeapObject Context::GetScopeInfo(Error& err) {
 }
 
 std::string Context::Inspect(Error& err) {
-  std::string res;
   // Not enough postmortem information, return bare minimum
   if (v8()->shared_info()->kScopeInfoOffset == -1 &&
       v8()->shared_info()->kNameOrScopeInfoOffset == -1)
-    return res;
+    return std::string();
+
+  std::string res = "<Context: {\n";
 
   Value previous = Previous(err);
   if (err.Fail()) return std::string();
@@ -1088,14 +1089,13 @@ std::string Context::Inspect(Error& err) {
   if (heap_previous.Check()) {
     char tmp[128];
     snprintf(tmp, sizeof(tmp), "    (previous)=0x%016" PRIx64, previous.raw());
-    res += tmp;
+    res += std::string(tmp) + ":<Context>,";
   }
 
   if (!res.empty()) res += "\n";
 
   if (v8()->context()->kClosureIndex != -1) {
-    JSFunction closure;
-    closure = Closure(err);
+    JSFunction closure = Closure(err);
     if (err.Fail()) return std::string();
     char tmp[128];
     snprintf(tmp, sizeof(tmp), "    (closure)=0x%016" PRIx64 " {",
@@ -1105,6 +1105,21 @@ std::string Context::Inspect(Error& err) {
     InspectOptions options;
     res += closure.Inspect(&options, err) + "}";
     if (err.Fail()) return std::string();
+  } else {
+    char tmp[128];
+    snprintf(tmp, sizeof(tmp), "    (scope_info)=0x%016" PRIx64,
+             scope.raw());
+
+    res += std::string(tmp) + ":<ScopeInfo";
+
+    Error function_name_error;
+    HeapObject maybe_function_name = scope.MaybeFunctionName(function_name_error);
+
+    if (function_name_error.Success()) {
+      res += ": for function " + String(maybe_function_name).ToString(err);
+    }
+
+    res += ">";
   }
 
   int param_count = param_count_smi.GetValue();
@@ -1126,7 +1141,7 @@ std::string Context::Inspect(Error& err) {
     if (err.Fail()) return std::string();
   }
 
-  return res;
+  return res + " }>";
 }
 
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1109,7 +1109,7 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
 
   if (!res.empty()) res += "\n";
 
-  if (v8()->context()->kClosureIndex != -1) {
+  if (v8()->context()->hasClosure()) {
     JSFunction closure = Closure(err);
     if (err.Fail()) return std::string();
     char tmp[128];

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -389,10 +389,15 @@ std::string JSFunction::Inspect(InspectOptions* options, Error& err) {
     snprintf(tmp, sizeof(tmp), "\n  context=0x%016" PRIx64, context.raw());
     res += tmp;
 
-    std::string context_str = context.Inspect(err);
-    if (err.Fail()) return std::string();
+    {
+      InspectOptions ctx_options;
+      ctx_options.detailed = true;
+      ctx_options.indent_depth = options->indent_depth + 1;
+      std::string context_str = context.Inspect(&ctx_options, err);
+      if (err.Fail()) return std::string();
 
-    if (!context_str.empty()) res += ":" + context_str;
+      if (!context_str.empty()) res += ":" + context_str;
+    }
 
     if (options->print_source) {
       SharedFunctionInfo info = Info(err);
@@ -821,6 +826,12 @@ std::string HeapObject::Inspect(InspectOptions* options, Error& err) {
     return pre + str.Inspect(options, err);
   }
 
+  if (type >= v8()->types()->kFirstContextType &&
+      type <= v8()->types()->kLastContextType) {
+    Context ctx(this);
+    return pre + ctx.Inspect(options, err);
+  }
+
   if (type == v8()->types()->kFixedArrayType) {
     FixedArray arr(this);
     return pre + arr.Inspect(options, err);
@@ -1060,13 +1071,19 @@ HeapObject Context::GetScopeInfo(Error& err) {
   return info.GetScopeInfo(err);
 }
 
-std::string Context::Inspect(Error& err) {
+std::string Context::Inspect(InspectOptions* options, Error& err) {
   // Not enough postmortem information, return bare minimum
   if (v8()->shared_info()->kScopeInfoOffset == -1 &&
       v8()->shared_info()->kNameOrScopeInfoOffset == -1)
     return std::string();
 
-  std::string res = "<Context: {\n";
+  std::string res = "<Context";
+
+  if (!options->detailed) {
+    return res + ">";
+  }
+
+  res += ": {\n";
 
   Value previous = Previous(err);
   if (err.Fail()) return std::string();
@@ -1083,12 +1100,10 @@ std::string Context::Inspect(Error& err) {
   Smi local_count_smi = scope.ContextLocalCount(err);
   if (err.Fail()) return std::string();
 
-  InspectOptions options;
-
   HeapObject heap_previous = HeapObject(previous);
   if (heap_previous.Check()) {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), "    (previous)=0x%016" PRIx64, previous.raw());
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(previous)=0x%016" PRIx64).c_str(), previous.raw());
     res += std::string(tmp) + ":<Context>,";
   }
 
@@ -1098,16 +1113,16 @@ std::string Context::Inspect(Error& err) {
     JSFunction closure = Closure(err);
     if (err.Fail()) return std::string();
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), "    (closure)=0x%016" PRIx64 " {",
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(closure)=0x%016" PRIx64 " {").c_str(),
              closure.raw());
     res += tmp;
 
-    InspectOptions options;
-    res += closure.Inspect(&options, err) + "}";
+    InspectOptions closure_options;
+    res += closure.Inspect(&closure_options, err) + "}";
     if (err.Fail()) return std::string();
   } else {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), "    (scope_info)=0x%016" PRIx64,
+    snprintf(tmp, sizeof(tmp), (options->get_indent_spaecs() + "(scope_info)=0x%016" PRIx64).c_str(),
              scope.raw());
 
     res += std::string(tmp) + ":<ScopeInfo";
@@ -1131,17 +1146,18 @@ std::string Context::Inspect(Error& err) {
 
     if (!res.empty()) res += ",\n";
 
-    res += "    " + name.ToString(err) + "=";
+    res += options->get_indent_spaecs() + name.ToString(err) + "=";
     if (err.Fail()) return std::string();
 
     Value value = ContextSlot(i, err);
     if (err.Fail()) return std::string();
 
-    res += value.Inspect(&options, err);
+    InspectOptions val_options;
+    res += value.Inspect(&val_options, err);
     if (err.Fail()) return std::string();
   }
 
-  return res + " }>";
+  return res + "}>";
 }
 
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -44,14 +44,20 @@ class Value {
         : detailed(false),
           print_map(false),
           print_source(false),
-          length(kLength) {}
+          length(kLength),
+          indent_depth(1) {}
 
     static const unsigned int kLength = 16;
+    static const unsigned int kIndentSize = 2;
+    inline std::string get_indent_spaecs() {
+      return std::string(indent_depth * kIndentSize, ' ');
+    }
 
     bool detailed;
     bool print_map;
     bool print_source;
     unsigned int length;
+    unsigned int indent_depth;
   };
 
   Value(const Value& v) = default;
@@ -390,7 +396,7 @@ class Context : public FixedArray {
   inline T GetEmbedderData(int64_t index, Error& err);
   inline Value ContextSlot(int index, Error& err);
 
-  std::string Inspect(Error& err);
+  std::string Inspect(InspectOptions *options, Error& err);
 
  private:
   inline JSFunction Closure(Error& err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -49,7 +49,7 @@ class Value {
 
     static const unsigned int kLength = 16;
     static const unsigned int kIndentSize = 2;
-    inline std::string get_indent_spaecs() {
+    inline std::string get_indent_spaces() {
       return std::string(indent_depth * kIndentSize, ' ');
     }
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -382,7 +382,7 @@ class Context : public FixedArray {
  public:
   V8_VALUE_DEFAULT_METHODS(Context, FixedArray)
 
-  inline JSFunction Closure(Error& err);
+  inline HeapObject GetScopeInfo(Error& err);
   inline Value Previous(Error& err);
   inline Value Native(Error& err);
   inline bool IsNative(Error& err);
@@ -391,6 +391,9 @@ class Context : public FixedArray {
   inline Value ContextSlot(int index, Error& err);
 
   std::string Inspect(Error& err);
+
+ private:
+  inline JSFunction Closure(Error& err);
 };
 
 class ScopeInfo : public FixedArray {


### PR DESCRIPTION
ETA: July 24th (after V8 6.8 lands on nodejs/node)

V8 6.8 replaces Closure inside Context with ScopeInfo. Those are minimal
changes to adopt llnode to the new behavior.

Ref: chromium-review.googlesource.com/#/c/785151
Fixes: #193
