### PR TITLE
src: move ParseInspectOptions out of CommandBase

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -28,63 +28,6 @@ using lldb::SBValue;
 using lldb::eReturnStatusFailed;
 using lldb::eReturnStatusSuccessFinishResult;
 
-char** CommandBase::ParseInspectOptions(char** cmd,
-                                        v8::Value::InspectOptions* options) {
-  static struct option opts[] = {
-      {"full-string", no_argument, nullptr, 'F'},
-      {"string-length", required_argument, nullptr, 'l'},
-      {"array-length", required_argument, nullptr, 'l'},
-      {"length", required_argument, nullptr, 'l'},
-      {"print-map", no_argument, nullptr, 'm'},
-      {"print-source", no_argument, nullptr, 's'},
-      {"verbose", no_argument, nullptr, 'v'},
-      {"detailed", no_argument, nullptr, 'd'},
-      {nullptr, 0, nullptr, 0}};
-
-  int argc = 1;
-  for (char** p = cmd; p != nullptr && *p != nullptr; p++) argc++;
-
-  char* args[argc];
-
-  // Make this look like a command line, we need a valid element at index 0
-  // for getopt_long to use in its error messages.
-  char name[] = "llnode";
-  args[0] = name;
-  for (int i = 0; i < argc - 1; i++) args[i + 1] = cmd[i];
-
-  // Reset getopts.
-  optind = 0;
-  opterr = 1;
-  do {
-    int arg = getopt_long(argc, args, "Fmsdvl:", opts, nullptr);
-    if (arg == -1) break;
-
-    switch (arg) {
-      case 'F':
-        options->length = 0;
-        break;
-      case 'm':
-        options->print_map = true;
-        break;
-      case 'l':
-        options->length = strtol(optarg, nullptr, 10);
-        break;
-      case 's':
-        options->print_source = true;
-        break;
-      case 'd':
-      case 'v':
-        options->detailed = true;
-        break;
-      default:
-        continue;
-    }
-  } while (true);
-
-  // Use the original cmd array for our return value.
-  return &cmd[optind - 1];
-}
-
 
 bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
                              SBCommandReturnObject& result) {

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -10,8 +10,6 @@
 namespace llnode {
 
 class CommandBase : public lldb::SBCommandPluginInterface {
- public:
-  char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options);
 };
 
 class BacktraceCmd : public CommandBase {

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -18,6 +18,7 @@ typedef std::map<uint64_t, ReferencesVector*> ReferencesByValueMap;
 typedef std::map<std::string, ReferencesVector*> ReferencesByPropertyMap;
 typedef std::map<std::string, ReferencesVector*> ReferencesByStringMap;
 
+char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options);
 
 class FindObjectsCmd : public CommandBase {
  public:


### PR DESCRIPTION
It is referenced in both llnode.cc and llscan.cc,
to make sure targets can compile by only including
llscan.h, this is the minimum change required.

Refs: https://github.com/nodejs/llnode/pull/206