### PR TITLE
 src: add commands to inspect the workqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ The following subcommands are supported:
                           * -n, --name  name     - all properties with the specified name
                           * -s, --string string  - all properties that refer to the specified JavaScript string value
 
+      getactivehandles  -- Print all pending handles in the queue. Equivalent to running process._getActiveHandles() on
+                           the living process.
+
+      getactiverequests -- Print all pending handles in the queue. Equivalent to running process._getActiveHandles() on
+                           the living process.
+
       inspect         -- Print detailed description and contents of the JavaScript value.
 
                          Possible flags (all optional):

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,7 @@
       "<(lldb_include_dir)",
     ],
 
+
     "cflags" : [ "-std=c++11" ],
 
     "conditions": [
@@ -76,6 +77,7 @@
       "src/llv8.cc",
       "src/llv8-constants.cc",
       "src/llscan.cc",
+      "src/node.cc",
       "src/node-constants.cc",
     ]
   }],

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,6 @@
       "<(lldb_include_dir)",
     ],
 
-
     "cflags" : [ "-std=c++11" ],
 
     "conditions": [

--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -4,6 +4,8 @@
 #include <string.h>
 
 #include <cinttypes>
+#include <sstream>
+#include <string>
 
 #include <lldb/API/SBExpressionOptions.h>
 
@@ -11,6 +13,7 @@
 #include "src/llnode.h"
 #include "src/llscan.h"
 #include "src/llv8.h"
+#include "src/node-inl.h"
 
 namespace llnode {
 
@@ -20,6 +23,7 @@ using lldb::SBDebugger;
 using lldb::SBError;
 using lldb::SBExpressionOptions;
 using lldb::SBFrame;
+using lldb::SBProcess;
 using lldb::SBStream;
 using lldb::SBSymbol;
 using lldb::SBTarget;
@@ -245,6 +249,112 @@ bool ListCmd::DoExecute(SBDebugger d, char** cmd,
   return true;
 }
 
+bool WorkqueueCmd::DoExecute(SBDebugger d, char** cmd,
+                             SBCommandReturnObject& result) {
+  SBTarget target = d.GetSelectedTarget();
+  SBProcess process = target.GetProcess();
+  SBThread thread = process.GetSelectedThread();
+  std::string result_message;
+  Error err;
+
+  llv8_->Load(target);
+  node_->Load(target);
+
+  if (!thread.IsValid()) {
+    result.SetError("No valid process, please start something\n");
+    return false;
+  }
+
+  node::Environment env = node::Environment::GetCurrent(node_, err);
+  if (err.Fail()) {
+    result.SetError(err.GetMessage());
+    return false;
+  }
+
+  result_message = GetResultMessage(&env, err);
+
+  if (err.Fail()) {
+    result.SetError(err.GetMessage());
+    return false;
+  }
+
+  result.Printf("%s", result_message.c_str());
+  return true;
+}
+
+std::string GetActiveHandlesCmd::GetResultMessage(node::Environment* env,
+                                                  Error& err) {
+  int active_handles = 0;
+  v8::Value::InspectOptions inspect_options;
+  inspect_options.detailed = true;
+  std::ostringstream result_message;
+
+  for (auto w : env->handle_wrap_queue()) {
+    addr_t persistent_addr = w.persistent_addr(err);
+    if (err.Fail()) {
+      break;
+    }
+    if (persistent_addr == 0) {
+      continue;
+    }
+
+    addr_t v8_object_addr = w.v8_object_addr(err);
+    if (err.Fail()) {
+      break;
+    }
+    v8::JSObject v8_object(llv8(), v8_object_addr);
+    std::string res = v8_object.Inspect(&inspect_options, err);
+    if (err.Fail()) {
+      Error::PrintInDebugMode("Failed to load object at address %" PRIx64,
+                              v8_object_addr);
+      break;
+    }
+
+    active_handles++;
+    result_message << res.c_str() << std::endl;
+  }
+
+  result_message << "Total: " << active_handles << std::endl;
+  return result_message.str();
+}
+
+
+std::string GetActiveRequestsCmd::GetResultMessage(node::Environment* env,
+                                                   Error& err) {
+  int active_handles = 0;
+  v8::Value::InspectOptions inspect_options;
+  inspect_options.detailed = true;
+  std::ostringstream result_message;
+
+  for (auto w : env->req_wrap_queue()) {
+    addr_t persistent_addr = w.persistent_addr(err);
+    if (err.Fail()) {
+      break;
+    }
+    if (persistent_addr == 0) {
+      continue;
+    }
+
+    addr_t v8_object_addr = w.v8_object_addr(err);
+    if (err.Fail()) {
+      break;
+    }
+    v8::JSObject v8_object(llv8(), v8_object_addr);
+    std::string res = v8_object.Inspect(&inspect_options, err);
+    if (err.Fail()) {
+      Error::PrintInDebugMode("Failed to load object at address %" PRIx64,
+                              v8_object_addr);
+      break;
+    }
+
+    active_handles++;
+    result_message << res.c_str() << std::endl;
+  }
+
+  result_message << "Total: " << active_handles << std::endl;
+  return result_message.str();
+}
+
 
 void InitDebugMode() {
   bool is_debug_mode = false;
@@ -264,6 +374,7 @@ bool PluginInitialize(SBDebugger d) {
   llnode::InitDebugMode();
 
   static llnode::v8::LLV8 llv8;
+  static llnode::node::Node node(&llv8);
   static llnode::LLScan llscan = llnode::LLScan(&llv8);
 
   SBCommandInterpreter interpreter = d.GetCommandInterpreter();
@@ -348,6 +459,16 @@ bool PluginInitialize(SBDebugger d) {
       " * -s, --string string  - all properties that refer to the specified "
       "JavaScript string value\n"
       "\n");
+
+  v8.AddCommand("getactivehandles",
+                new llnode::GetActiveHandlesCmd(&llv8, &node),
+                "Print all pending handles in the queue. Equivalent to running "
+                "process._getActiveHandles() on the living process.\n");
+
+  v8.AddCommand(
+      "getactiverequests", new llnode::GetActiveRequestsCmd(&llv8, &node),
+      "Print all pending requests in the queue. Equivalent to "
+      "running process._getActiveRequests() on the living process.\n");
 
   return true;
 }

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -6,6 +6,7 @@
 #include <lldb/API/LLDB.h>
 
 #include "src/llv8.h"
+#include "src/node.h"
 
 namespace llnode {
 
@@ -49,6 +50,43 @@ class ListCmd : public CommandBase {
  private:
   v8::LLV8* llv8_;
 };
+
+class WorkqueueCmd : public CommandBase {
+ public:
+  WorkqueueCmd(v8::LLV8* llv8, node::Node* node) : llv8_(llv8), node_(node) {}
+  ~WorkqueueCmd() override {}
+
+  inline v8::LLV8* llv8() { return llv8_; };
+  inline node::Node* node() { return node_; };
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+
+  virtual std::string GetResultMessage(node::Environment* env, Error& err) {
+    return std::string();
+  };
+
+ private:
+  v8::LLV8* llv8_;
+  node::Node* node_;
+};
+
+class GetActiveHandlesCmd : public WorkqueueCmd {
+ public:
+  GetActiveHandlesCmd(v8::LLV8* llv8, node::Node* node)
+      : WorkqueueCmd(llv8, node) {}
+
+  std::string GetResultMessage(node::Environment* env, Error& err) override;
+};
+
+class GetActiveRequestsCmd : public WorkqueueCmd {
+ public:
+  GetActiveRequestsCmd(v8::LLV8* llv8, node::Node* node)
+      : WorkqueueCmd(llv8, node) {}
+
+  std::string GetResultMessage(node::Environment* env, Error& err) override;
+};
+
 
 }  // namespace llnode
 

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -10,8 +10,7 @@
 
 namespace llnode {
 
-class CommandBase : public lldb::SBCommandPluginInterface {
-};
+class CommandBase : public lldb::SBCommandPluginInterface {};
 
 class BacktraceCmd : public CommandBase {
  public:

--- a/src/node-constants.cc
+++ b/src/node-constants.cc
@@ -19,7 +19,8 @@ void Environment::Load() {
   kHandleWrapQueueOffset = LoadConstant(
       "offset_Environment__handle_wrap_queue___Environment_HandleWrapQueue");
   kEnvContextEmbedderDataIndex =
-      LoadConstant("const_Environment__kContextEmbedderDataIndex__int");
+      LoadConstant("const_Environment__kContextEmbedderDataIndex__int",
+                   "const_ContextEmbedderIndex__kEnvironment__int");
 
   Error err;
   kCurrentEnvironment = LoadCurrentEnvironment(err);

--- a/src/node-inl.h
+++ b/src/node-inl.h
@@ -1,0 +1,42 @@
+#include "node.h"
+
+namespace llnode {
+namespace node {
+
+template <typename T, typename C>
+T Queue<T, C>::Iterator::operator*() const {
+  return T::FromListNode(node_, current_);
+}
+
+template <typename T, typename C>
+const typename Queue<T, C>::Iterator Queue<T, C>::Iterator::operator++() {
+  lldb::SBError sberr;
+
+  addr_t current = current_ + constants_->kNextOffset;
+  current = node_->process().ReadPointerFromMemory(current, sberr);
+  current_ = current;
+  return Iterator(node_, current, constants_);
+}
+
+template <typename T, typename C>
+bool Queue<T, C>::Iterator::operator!=(const Iterator& that) const {
+  return current_ != that.current_;
+}
+
+template <typename T, typename C>
+typename Queue<T, C>::Iterator Queue<T, C>::begin() const {
+  lldb::SBError sberr;
+  addr_t currentNode = raw_ + constants_->kHeadOffset;
+
+  currentNode = currentNode + constants_->kNextOffset;
+  currentNode = node_->process().ReadPointerFromMemory(currentNode, sberr);
+
+  return Iterator(node_, currentNode, constants_);
+}
+
+template <typename T, typename C>
+typename Queue<T, C>::Iterator Queue<T, C>::end() const {
+  return Iterator(node_, raw_ + constants_->kHeadOffset, constants_);
+}
+}  // namespace node
+}  // namespace llnode

--- a/src/node-inl.h
+++ b/src/node-inl.h
@@ -12,8 +12,8 @@ template <typename T, typename C>
 const typename Queue<T, C>::Iterator Queue<T, C>::Iterator::operator++() {
   lldb::SBError sberr;
 
-  current_ =
-      node_->process().ReadPointerFromMemory(current_ + constants_->kNextOffset, sberr);
+  current_ = node_->process().ReadPointerFromMemory(
+      current_ + constants_->kNextOffset, sberr);
   return Iterator(node_, current_, constants_);
 }
 
@@ -26,8 +26,7 @@ template <typename T, typename C>
 typename Queue<T, C>::Iterator Queue<T, C>::begin() const {
   lldb::SBError sberr;
 
-  addr_t first =
-      node_->process().ReadPointerFromMemory(next(head()), sberr);
+  addr_t first = node_->process().ReadPointerFromMemory(next(head()), sberr);
   return Iterator(node_, first, constants_);
 }
 

--- a/src/node-inl.h
+++ b/src/node-inl.h
@@ -32,7 +32,7 @@ typename Queue<T, C>::Iterator Queue<T, C>::begin() const {
 
 template <typename T, typename C>
 typename Queue<T, C>::Iterator Queue<T, C>::end() const {
-  return Iterator(node_, raw_ + constants_->kHeadOffset, constants_);
+  return Iterator(node_, head(), constants_);
 }
 }  // namespace node
 }  // namespace llnode

--- a/src/node-inl.h
+++ b/src/node-inl.h
@@ -5,17 +5,16 @@ namespace node {
 
 template <typename T, typename C>
 T Queue<T, C>::Iterator::operator*() const {
-  return T::FromListNode(node_, current_);
+  return T::GetItemFromList(node_, current_);
 }
 
 template <typename T, typename C>
 const typename Queue<T, C>::Iterator Queue<T, C>::Iterator::operator++() {
   lldb::SBError sberr;
 
-  addr_t current = current_ + constants_->kNextOffset;
-  current = node_->process().ReadPointerFromMemory(current, sberr);
-  current_ = current;
-  return Iterator(node_, current, constants_);
+  current_ =
+      node_->process().ReadPointerFromMemory(current_ + constants_->kNextOffset, sberr);
+  return Iterator(node_, current_, constants_);
 }
 
 template <typename T, typename C>
@@ -26,12 +25,10 @@ bool Queue<T, C>::Iterator::operator!=(const Iterator& that) const {
 template <typename T, typename C>
 typename Queue<T, C>::Iterator Queue<T, C>::begin() const {
   lldb::SBError sberr;
-  addr_t currentNode = raw_ + constants_->kHeadOffset;
 
-  currentNode = currentNode + constants_->kNextOffset;
-  currentNode = node_->process().ReadPointerFromMemory(currentNode, sberr);
-
-  return Iterator(node_, currentNode, constants_);
+  addr_t first =
+      node_->process().ReadPointerFromMemory(next(head()), sberr);
+  return Iterator(node_, first, constants_);
 }
 
 template <typename T, typename C>

--- a/src/node.cc
+++ b/src/node.cc
@@ -1,0 +1,77 @@
+#include "node.h"
+
+namespace llnode {
+namespace node {
+
+addr_t BaseObject::persistent_addr(Error& err) {
+  lldb::SBError sberr;
+
+  addr_t persistentHandlePtr =
+      raw_ + node_->base_object()->kPersistentHandleOffset;
+  addr_t persistentHandle =
+      node_->process().ReadPointerFromMemory(persistentHandlePtr, sberr);
+  if (sberr.Fail()) {
+    err = Error::Failure("Failed to load persistent handle");
+    return 0;
+  }
+  return persistentHandle;
+}
+
+addr_t BaseObject::v8_object_addr(Error& err) {
+  lldb::SBError sberr;
+
+  addr_t persistentHandle = persistent_addr(err);
+  addr_t obj = node_->process().ReadPointerFromMemory(persistentHandle, sberr);
+  if (sberr.Fail()) {
+    err = Error::Failure("Failed to load object from persistent handle");
+    return 0;
+  }
+  return obj;
+}
+
+HandleWrap HandleWrap::FromListNode(Node* node, addr_t list_node_addr) {
+  return HandleWrap(node,
+                    list_node_addr - node->handle_wrap()->kListNodeOffset);
+}
+
+ReqWrap ReqWrap::FromListNode(Node* node, addr_t list_node_addr) {
+  return ReqWrap(node, list_node_addr - node->req_wrap()->kListNodeOffset);
+}
+
+Environment Environment::GetCurrent(Node* node, Error& err) {
+  addr_t envAddr = node->env()->kCurrentEnvironment;
+  if (envAddr == 0) {
+    err = Error::Failure("Couldn't get node's Environment");
+  }
+
+  return Environment(node, envAddr);
+}
+
+HandleWrapQueue Environment::handle_wrap_queue() const {
+  return HandleWrapQueue(node_, raw_ + node_->env()->kHandleWrapQueueOffset,
+                         node_->handle_wrap_queue());
+}
+
+ReqWrapQueue Environment::req_wrap_queue() const {
+  return ReqWrapQueue(node_, raw_ + node_->env()->kReqWrapQueueOffset,
+                      node_->req_wrap_queue());
+}
+
+void Node::Load(SBTarget target) {
+  // Reload process anyway
+  process_ = target.GetProcess();
+
+  // No need to reload
+  if (target_ == target) return;
+
+  target_ = target;
+
+  env.Assign(target);
+  req_wrap_queue.Assign(target);
+  req_wrap.Assign(target);
+  handle_wrap_queue.Assign(target);
+  handle_wrap.Assign(target);
+  base_object.Assign(target);
+}
+}  // namespace node
+}  // namespace llnode

--- a/src/node.cc
+++ b/src/node.cc
@@ -6,8 +6,7 @@ namespace node {
 addr_t BaseObject::Persistent(Error& err) {
   lldb::SBError sberr;
 
-  addr_t persistent_ptr =
-      raw_ + node_->base_object()->kPersistentHandleOffset;
+  addr_t persistent_ptr = raw_ + node_->base_object()->kPersistentHandleOffset;
   addr_t persistent =
       node_->process().ReadPointerFromMemory(persistent_ptr, sberr);
   if (sberr.Fail()) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -3,25 +3,25 @@
 namespace llnode {
 namespace node {
 
-addr_t BaseObject::persistent_addr(Error& err) {
+addr_t BaseObject::Persistent(Error& err) {
   lldb::SBError sberr;
 
-  addr_t persistentHandlePtr =
+  addr_t persistent_ptr =
       raw_ + node_->base_object()->kPersistentHandleOffset;
-  addr_t persistentHandle =
-      node_->process().ReadPointerFromMemory(persistentHandlePtr, sberr);
+  addr_t persistent =
+      node_->process().ReadPointerFromMemory(persistent_ptr, sberr);
   if (sberr.Fail()) {
     err = Error::Failure("Failed to load persistent handle");
     return 0;
   }
-  return persistentHandle;
+  return persistent;
 }
 
-addr_t BaseObject::v8_object_addr(Error& err) {
+addr_t BaseObject::Object(Error& err) {
   lldb::SBError sberr;
 
-  addr_t persistentHandle = persistent_addr(err);
-  addr_t obj = node_->process().ReadPointerFromMemory(persistentHandle, sberr);
+  addr_t persistent = Persistent(err);
+  addr_t obj = node_->process().ReadPointerFromMemory(persistent, sberr);
   if (sberr.Fail()) {
     err = Error::Failure("Failed to load object from persistent handle");
     return 0;
@@ -29,12 +29,12 @@ addr_t BaseObject::v8_object_addr(Error& err) {
   return obj;
 }
 
-HandleWrap HandleWrap::FromListNode(Node* node, addr_t list_node_addr) {
+HandleWrap HandleWrap::GetItemFromList(Node* node, addr_t list_node_addr) {
   return HandleWrap(node,
                     list_node_addr - node->handle_wrap()->kListNodeOffset);
 }
 
-ReqWrap ReqWrap::FromListNode(Node* node, addr_t list_node_addr) {
+ReqWrap ReqWrap::GetItemFromList(Node* node, addr_t list_node_addr) {
   return ReqWrap(node, list_node_addr - node->req_wrap()->kListNodeOffset);
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -1,0 +1,134 @@
+#ifndef SRC_NODE_H_
+#define SRC_NODE_H_
+
+#include <lldb/API/LLDB.h>
+#include <list>
+
+#include "node-constants.h"
+
+#define CONSTANTS_LIST(V)               \
+  V(Environment, env)                   \
+  V(ReqWrapQueue, req_wrap_queue)       \
+  V(ReqWrap, req_wrap)                  \
+  V(HandleWrapQueue, handle_wrap_queue) \
+  V(HandleWrap, handle_wrap)            \
+  V(BaseObject, base_object)
+
+namespace llnode {
+namespace node {
+
+class Node;
+class HandleWrap;
+class ReqWrap;
+template <typename T, typename C>
+class Queue;
+
+class BaseNode {
+ public:
+  BaseNode(Node* node) : node_(node){};
+
+ protected:
+  Node* node_;
+};
+
+typedef Queue<HandleWrap, constants::HandleWrapQueue> HandleWrapQueue;
+typedef Queue<ReqWrap, constants::ReqWrapQueue> ReqWrapQueue;
+
+class Environment : public BaseNode {
+ public:
+  Environment(Node* node, addr_t raw) : BaseNode(node), raw_(raw){};
+  inline addr_t raw() { return raw_; };
+
+  static Environment GetCurrent(Node* node, Error& err);
+
+  HandleWrapQueue handle_wrap_queue() const;
+  ReqWrapQueue req_wrap_queue() const;
+
+ private:
+  addr_t raw_;
+};
+
+class BaseObject : public BaseNode {
+ public:
+  BaseObject(Node* node, addr_t raw) : BaseNode(node), raw_(raw){};
+  inline addr_t raw() { return raw_; };
+
+  addr_t persistent_addr(Error& err);
+
+  addr_t v8_object_addr(Error& err);
+
+
+ private:
+  addr_t raw_;
+};
+
+class AsyncWrap : public BaseObject {
+ public:
+  AsyncWrap(Node* node, addr_t raw) : BaseObject(node, raw){};
+};
+
+class HandleWrap : public AsyncWrap {
+ public:
+  HandleWrap(Node* node, addr_t raw) : AsyncWrap(node, raw){};
+
+  static HandleWrap FromListNode(Node* node, addr_t list_node_addr);
+};
+
+class ReqWrap : public AsyncWrap {
+ public:
+  ReqWrap(Node* node, addr_t raw) : AsyncWrap(node, raw){};
+
+  static ReqWrap FromListNode(Node* node, addr_t list_node_addr);
+};
+
+class Node {
+ public:
+#define V(Class, Attribute) Attribute(constants::Class(llv8)),
+  Node(v8::LLV8* llv8) : CONSTANTS_LIST(V) target_(lldb::SBTarget()) {}
+#undef V
+
+  inline lldb::SBProcess process() { return process_; };
+
+  void Load(lldb::SBTarget target);
+
+#define V(Class, Attribute) constants::Class Attribute;
+  CONSTANTS_LIST(V)
+#undef V
+
+ private:
+  lldb::SBTarget target_;
+  lldb::SBProcess process_;
+};
+
+template <typename T, typename C>
+class Queue : public BaseNode {
+  class Iterator : public BaseNode {
+   public:
+    inline T operator*() const;
+    inline const Iterator operator++();
+    inline bool operator!=(const Iterator& that) const;
+
+
+    inline Iterator(Node* node, addr_t current, C* constants)
+        : BaseNode(node), current_(current), constants_(constants){};
+
+   public:
+    addr_t current_;
+    C* constants_;
+  };
+
+ public:
+  inline Queue(Node* node, addr_t raw, C* constants)
+      : BaseNode(node), raw_(raw), constants_(constants){};
+
+  inline Iterator begin() const;
+  inline Iterator end() const;
+
+ private:
+  addr_t raw_;
+  C* constants_;
+};
+}  // namespace node
+}  // namespace llnode
+
+#endif

--- a/src/node.h
+++ b/src/node.h
@@ -31,8 +31,8 @@ class BaseNode {
   Node* node_;
 };
 
-typedef Queue<HandleWrap, constants::HandleWrapQueue> HandleWrapQueue;
-typedef Queue<ReqWrap, constants::ReqWrapQueue> ReqWrapQueue;
+using HandleWrapQueue = Queue<HandleWrap, constants::HandleWrapQueue>;
+using ReqWrapQueue = Queue<ReqWrap, constants::ReqWrapQueue>;
 
 class Environment : public BaseNode {
  public:
@@ -53,10 +53,8 @@ class BaseObject : public BaseNode {
   BaseObject(Node* node, addr_t raw) : BaseNode(node), raw_(raw){};
   inline addr_t raw() { return raw_; };
 
-  addr_t persistent_addr(Error& err);
-
-  addr_t v8_object_addr(Error& err);
-
+  addr_t Persistent(Error& err);
+  addr_t Object(Error& err);
 
  private:
   addr_t raw_;
@@ -71,14 +69,14 @@ class HandleWrap : public AsyncWrap {
  public:
   HandleWrap(Node* node, addr_t raw) : AsyncWrap(node, raw){};
 
-  static HandleWrap FromListNode(Node* node, addr_t list_node_addr);
+  static HandleWrap GetItemFromList(Node* node, addr_t list_node_addr);
 };
 
 class ReqWrap : public AsyncWrap {
  public:
   ReqWrap(Node* node, addr_t raw) : AsyncWrap(node, raw){};
 
-  static ReqWrap FromListNode(Node* node, addr_t list_node_addr);
+  static ReqWrap GetItemFromList(Node* node, addr_t list_node_addr);
 };
 
 class Node {
@@ -125,6 +123,13 @@ class Queue : public BaseNode {
   inline Iterator end() const;
 
  private:
+  inline addr_t head() const {
+    return raw_ + constants_->kHeadOffset;
+  }
+  inline addr_t next(addr_t item) const {
+    return item + constants_->kNextOffset;
+  }
+
   addr_t raw_;
   C* constants_;
 };

--- a/src/node.h
+++ b/src/node.h
@@ -123,9 +123,7 @@ class Queue : public BaseNode {
   inline Iterator end() const;
 
  private:
-  inline addr_t head() const {
-    return raw_ + constants_->kHeadOffset;
-  }
+  inline addr_t head() const { return raw_ + constants_->kHeadOffset; }
   inline addr_t next(addr_t item) const {
     return item + constants_->kNextOffset;
   }

--- a/test/common.js
+++ b/test/common.js
@@ -89,14 +89,12 @@ SessionOutput.prototype.timeoutAfter = function timeoutAfter(timeout) {
   this.timeout = timeout;
 };
 
-SessionOutput.prototype.wait = function wait(regexp, callback, allLines,
-                                             outputOnTimeout) {
+SessionOutput.prototype.wait = function wait(regexp, callback, allLines) {
   if (!this._queueWait(() => { this.wait(regexp, callback, allLines); }))
     return;
 
   const self = this;
   const lines = [];
-  outputOnTimeout = outputOnTimeout == undefined ? true : outputOnTimeout;
 
   function onLine(line) {
     lines.push(line);
@@ -119,11 +117,9 @@ SessionOutput.prototype.wait = function wait(regexp, callback, allLines,
 
     self.removeListener('line', onLine);
     self._unqueueWait();
-    if (outputOnTimeout) {
-      console.error(`${'='.repeat(10)} lldb output ${'='.repeat(10)}`);
-      console.error(lines.join('\n'));
-      console.error('='.repeat(33));
-    }
+    console.error(`${'='.repeat(10)} lldb output ${'='.repeat(10)}`);
+    console.error(lines.join('\n'));
+    console.error('='.repeat(33));
     const message = `Test timeout in ${this.timeout} ` +
       `waiting for ${regexp}`;
     callback(new Error(message));

--- a/test/fixtures/workqueue-scenario.js
+++ b/test/fixtures/workqueue-scenario.js
@@ -1,0 +1,15 @@
+'use strict';
+const http = require('http')
+var fs = require('fs');
+
+// Creates a Timer to be inspected with getactivehandles
+setInterval(()=>{}, 500);
+
+// Creates a TCP to be inspected with getactivehandles
+const server = http.createServer((req, res) => { res.end('test'); });
+server.listen(4321, (err) => {});
+
+// Creates a FSReqWrap to be inspected with getactivehandles
+fs.readFile('invalidFile', (err, data) => {});
+
+uncaughtException();

--- a/test/fixtures/workqueue-scenario.js
+++ b/test/fixtures/workqueue-scenario.js
@@ -3,7 +3,7 @@ const http = require('http')
 var fs = require('fs');
 
 // Creates a Timer to be inspected with getactivehandles
-setInterval(()=>{}, 500);
+setInterval(() => {}, 500);
 
 // Creates a TCP to be inspected with getactivehandles
 const server = http.createServer((req, res) => { res.end('test'); });

--- a/test/workqueue-test.js
+++ b/test/workqueue-test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const tape = require('tape');
+
+const common = require('./common');
+
+function testWorkqueueCommands(t, sess) {
+  sess.send('v8 getactivehandles');
+
+  sess.wait(/TCP/, (err, line) => {
+    t.error(err);
+    let match = line.match(/<Object: TCP/i);
+    t.ok(match, 'TCP handler should be an Object');
+
+    sess.send('v8 getactivehandles');
+  });
+
+  sess.wait(/Timer/, (err, line) => {
+    t.error(err);
+    let match = line.match(/<Object: Timer/i);
+    t.ok(match, 'Timer handler should be an Object');
+
+    sess.send('v8 getactiverequests');
+  });
+
+  sess.wait(/FSReqWrap/, (err, line) => {
+    t.error(err);
+    let match = line.match(/<Object: FSReqWrap/i);
+    t.ok(match, 'FSReqWrap handler should be an Object');
+
+    sess.quit();
+    t.end();
+  });
+}
+
+tape('v8 workqueue commands', (t) => {
+  t.timeoutAfter(15000);
+
+  const sess = common.Session.create('workqueue-scenario.js');
+  sess.timeoutAfter
+
+  sess.waitBreak((err) => {
+    t.error(err);
+    sess.send('v8 getactivehandles');
+  });
+
+  // Check if current node version support these commands.
+  sess.waitError(/error: Couldn't get node's Environment/, (err, line) => {
+    if (err) {
+      testWorkqueueCommands(t, sess);
+    } else {
+      // TODO (mmarchini): print node's version from core.
+      t.skip(`workqueue commands can't be tested with this version of node`);
+      sess.quit();
+      t.end();
+    }
+  }, false, false);
+});


### PR DESCRIPTION
Add two new commands: `v8 getactivehandles` and `v8 getactiverequests`.
These commands will print all pending handles and requests. The result
should be similar to running process._getActiveHandles() and
process._getActiveRequests() on the living process.

Fixes: #100