### PR TITLE
src: fix JSError inspection

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -490,6 +490,7 @@ void Types::Load() {
   kFirstContextType = LoadConstant("FirstContextType");
   kLastContextType = LoadConstant("LastContextType");
 
+  kJSErrorType = LoadConstant("type_JSError__JS_ERROR_TYPE");
   kHeapNumberType = LoadConstant("type_HeapNumber__HEAP_NUMBER_TYPE");
   kMapType = LoadConstant("type_Map__MAP_TYPE");
   kGlobalObjectType =

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -478,6 +478,7 @@ class Types : public Module {
   int64_t kFirstContextType;
   int64_t kLastContextType;
 
+  int64_t kJSErrorType;
   int64_t kHeapNumberType;
   int64_t kMapType;
   int64_t kGlobalObjectType;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -211,6 +211,7 @@ ACCESSOR(JSObject, Elements, js_object()->kElementsOffset, HeapObject)
 inline bool JSObject::IsObjectType(LLV8* v8, int64_t type) {
   return type == v8->types()->kJSObjectType ||
          type == v8->types()->kJSAPIObjectType ||
+         type == v8->types()->kJSErrorType ||
          type == v8->types()->kJSSpecialAPIObjectType;
 }
 

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -57,6 +57,10 @@ function closure() {
   );
   c.hashmap['buffer'] = Buffer.from([0xff, 0xf0, 0x80, 0x0f, 0x01, 0x00]);
 
+  c.hashmap['error'] = new Error('test');
+  c.hashmap['error'].code = 'ERR_TEST';
+  c.hashmap['error'].errno = 1;
+
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;
   c.hashmap[23] = /regexp/;

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -136,7 +136,24 @@ const hashMapTests = {
   // .error=0x0000392d5d661119:<Object: Error>
   'error': {
     re: /.error=(0x[0-9a-f]+):<Object: Error>/,
-    desc: '.error Error property'
+    desc: '.error Error property',
+    validator(t, sess, addresses, name, cb) {
+      const address = addresses[name];
+      sess.send(`v8 inspect ${address}`);
+
+      sess.linesUntil(/}>/, (err, lines) => {
+        if (err) return cb(err);
+        lines = lines.join('\n');
+
+        let codeMatch = lines.match(/code=(0x[0-9a-f]+):<String: "ERR_TEST">/i);
+        t.ok(codeMatch, 'hashmap.error.code should be "ERR_TEST"');
+
+        let errnoMatch = lines.match(/errno=<Smi: 1>/i);
+        t.ok(errnoMatch, 'hashmap.error.errno should be 1');
+
+        cb(null);
+      });
+    }
   },
   // .array=0x000003df9cbe7919:<Array: length=6>,
   'array': {

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -133,6 +133,11 @@ const hashMapTests = {
     re: /.sliced-externalized-string=(0x[0-9a-f]+):<String: "\(external\)">/,
     desc: '.sliced-externalized-string Sliced ExternalString property'
   },
+  // .error=0x0000392d5d661119:<Object: Error>
+  'error': {
+    re: /.error=(0x[0-9a-f]+):<Object: Error>/,
+    desc: '.error Error property'
+  },
   // .array=0x000003df9cbe7919:<Array: length=6>,
   'array': {
     re: /.array=(0x[0-9a-f]+):<Array: length=6>/,


### PR DESCRIPTION
This commit fixes JSError inspection for Node.js v7+. We still need to
figure out a way to get the stack from the Error object though.

Ref: https://github.com/nodejs/llnode/issues/143