### PR TITLE
src: check oob before slicing String

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -17,6 +17,8 @@
 
 namespace llnode {
 
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
 using lldb::SBCommandInterpreter;
 using lldb::SBCommandReturnObject;
 using lldb::SBDebugger;
@@ -28,8 +30,6 @@ using lldb::SBSymbol;
 using lldb::SBTarget;
 using lldb::SBThread;
 using lldb::SBValue;
-using lldb::eReturnStatusFailed;
-using lldb::eReturnStatusSuccessFinishResult;
 
 
 bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -18,6 +18,8 @@
 namespace llnode {
 
 using lldb::ByteOrder;
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
 using lldb::SBCommandReturnObject;
 using lldb::SBDebugger;
 using lldb::SBError;
@@ -25,8 +27,6 @@ using lldb::SBExpressionOptions;
 using lldb::SBStream;
 using lldb::SBTarget;
 using lldb::SBValue;
-using lldb::eReturnStatusFailed;
-using lldb::eReturnStatusSuccessFinishResult;
 
 const char* const
     FindReferencesCmd::ObjectScanner::property_reference_template =

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -13,6 +13,7 @@ namespace llnode {
 namespace v8 {
 namespace constants {
 
+using lldb::addr_t;
 using lldb::SBAddress;
 using lldb::SBError;
 using lldb::SBProcess;
@@ -20,7 +21,6 @@ using lldb::SBSymbol;
 using lldb::SBSymbolContext;
 using lldb::SBSymbolContextList;
 using lldb::SBTarget;
-using lldb::addr_t;
 
 void Module::Assign(SBTarget target, Common* common) {
   loaded_ = false;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -420,6 +420,17 @@ inline std::string SlicedString::ToString(Error& err) {
   std::string tmp = parent.ToString(err);
   if (err.Fail()) return std::string();
 
+  int64_t off = offset.GetValue();
+  int64_t len = length.GetValue();
+  int64_t tmp_size = tmp.size();
+  if (off > tmp_size || len > tmp_size) {
+    err = Error::Failure("Failed to display sliced string 0x%016" PRIx64
+                         " (offset = 0x%016" PRIx64 ", length = 0x%016" PRIx64
+                         ") from parent string 0x%016" PRIx64
+                         " (length = 0x%016" PRIx64 ")",
+                         raw(), off, len, parent.raw(), tmp_size);
+    return std::string(err.GetMessage());
+  }
   return tmp.substr(offset.GetValue(), length.GetValue());
 }
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -10,9 +10,9 @@
 namespace llnode {
 namespace v8 {
 
+using lldb::addr_t;
 using lldb::SBError;
 using lldb::SBTarget;
-using lldb::addr_t;
 
 static std::string kConstantPrefix = "v8dbg_";
 

--- a/src/node-constants.h
+++ b/src/node-constants.h
@@ -95,7 +95,7 @@ class BaseObject : public Module {
  protected:
   void Load();
 };
-}
+}  // namespace constants
 }  // namespace node
 }  // namespace llnode
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/llnode/issues/216

The first commit runs clang-format on the src since it's a bit out of sync now.