### PR TITLE
build, doc: drop support for Node.js v9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,6 @@ matrix:
         - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
       install: npm install --llnode_build_addon=true
       script: TEST_LLDB_BINARY=`which lldb-3.9` npm run test-all
-      node_js: "9"
-    - sudo: required
-      dist: trusty
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install lldb-3.9 liblldb-3.9-dev -y
-      install: npm install --llnode_build_addon=true
-      script: TEST_LLDB_BINARY=`which lldb-3.9` npm run test-all
       node_js: "10"
     # Test Node.js master nightly build
     # Addon is not tested due to lack of node-addon-api
@@ -73,11 +65,6 @@ matrix:
       install: npm install --llnode_build_addon=true
       script: npm run test-all
       node_js: "8"
-    - os: osx
-      osx_image: xcode9.3
-      install: npm install --llnode_build_addon=true
-      script: npm run test-all
-      node_js: "9"
     - os: osx
       osx_image: xcode9.3
       install: npm install --llnode_build_addon=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 matrix:
   include:
-    # Test on Ubuntu Trusty
-    - sudo: required
+    #################
+    # Ubuntu Trusty #
+    #################
+
+    - name: "[Trusty] Node.js v6.x"
+      sudo: required
       dist: trusty
       before_install:
         - sudo apt-get -qq update
@@ -10,7 +14,9 @@ matrix:
       install: npm install --llnode_build_addon=true
       script: TEST_LLDB_BINARY=`which lldb-3.9` npm run test-all
       node_js: "6"
-    - sudo: required
+
+    - name: "[Trusty] Node.js v8.x"
+      sudo: required
       dist: trusty
       before_install:
         - sudo apt-get -qq update
@@ -18,7 +24,9 @@ matrix:
       install: npm install --llnode_build_addon=true
       script: TEST_LLDB_BINARY=`which lldb-3.9` npm run test-all
       node_js: "8"
-    - sudo: required
+
+    - name: "[Trusty] Node.js v10.x"
+      sudo: required
       dist: trusty
       before_install:
         - sudo apt-get -qq update
@@ -26,9 +34,15 @@ matrix:
       install: npm install --llnode_build_addon=true
       script: TEST_LLDB_BINARY=`which lldb-3.9` npm run test-all
       node_js: "10"
-    # Test Node.js master nightly build
+
+
+    ###########################
+    # Nightlies & V8 Canaries #
+    ###########################
+
     # Addon is not tested due to lack of node-addon-api
-    - node_js: "node"
+    - name: "[Trusty] Node.js Nightly"
+      node_js: "node"
       sudo: required
       dist: trusty
       before_install:
@@ -40,9 +54,10 @@ matrix:
       env:
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
         - NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
-    # Test Node.js v8-canary nightly build
+
     # Addon is not tested due to lack of node-addon-api
-    - node_js: "node"
+    - name: "[Trusty] Node.js V8 Canary"
+      node_js: "node"
       sudo: required
       dist: trusty
       before_install:
@@ -54,30 +69,42 @@ matrix:
       env:
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
         - NODEJS_ORG_MIRROR=https://nodejs.org/download/v8-canary
-    # Test on OS X
-    - os: osx
+
+    ########
+    # OS X #
+    ########
+
+    - name: "[OSX] Node.js v6.x"
+      os: osx
       osx_image: xcode9.3
       install: npm install --llnode_build_addon=true
       script: npm run test-all
       node_js: "6"
-    - os: osx
+
+    - name: "[OSX] Node.js v8.x"
+      os: osx
       osx_image: xcode9.3
       install: npm install --llnode_build_addon=true
       script: npm run test-all
       node_js: "8"
-    - os: osx
+
+    - name: "[OSX] Node.js v10.x"
+      os: osx
       osx_image: xcode9.3
       install: npm install --llnode_build_addon=true
       script: npm run test-all
       node_js: "10"
+
+  # Allow the nightly installs to fail
   allow_failures:
-    # Allow the nightly installs to fail
+
     - node_js: "node"
       sudo: required
       dist: trusty
       env:
         - NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
         - NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+
     - node_js: "node"
       sudo: required
       dist: trusty

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ https://asciinema.org/a/29589
 
 ## Build Status
 
-| Version | v6.x                    | v8.x                    | v9.x                    | v10.x                     | master                        | v8-canary                        |
-|---------|-------------------------|-------------------------|-------------------------|---------------------------|-------------------------------|----------------------------------|
-| **Trusty**  | [![v6.x badge][v6-trusty-badge]][travis] | [![v8.x badge][v8-trusty-badge]][travis] | [![v9.x badge][v9-trusty-badge]][travis] | [![v10.x badge][v10-trusty-badge]][travis] | [![master badge][master-trusty-badge]][travis] | [![v8-canary badge][canary-trusty-badge]][travis] |
-| **OS X**  | [![v6.x badge][v6-osx-badge]][travis] | [![v8.x badge][v8-osx-badge]][travis] | [![v9.x badge][v9-osx-badge]][travis] | [![v10.x badge][v10-osx-badge]][travis] | - | - |
+| Version | v6.x                    | v8.x                    | v10.x                     | master                        | v8-canary                        |
+|---------|-------------------------|-------------------------|---------------------------|-------------------------------|----------------------------------|
+| **Trusty**  | [![v6.x badge][v6-trusty-badge]][travis] | [![v8.x badge][v8-trusty-badge]][travis] | [![v10.x badge][v10-trusty-badge]][travis] | [![master badge][master-trusty-badge]][travis] | [![v8-canary badge][canary-trusty-badge]][travis] |
+| **OS X**  | [![v6.x badge][v6-osx-badge]][travis] | [![v8.x badge][v8-osx-badge]][travis] | [![v10.x badge][v10-osx-badge]][travis] | - | - |
 
 We have nightly test runs against all Node.js active release lines. We also test
 against Node.js master and Node.js v8-canary nightly builds to help us identify
@@ -376,13 +376,11 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 [travis]: https://travis-ci.com/nodejs/llnode
 [v6-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/1?use_travis_com=true
 [v8-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/2?use_travis_com=true
-[v9-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/3?use_travis_com=true
-[v10-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/4?use_travis_com=true
+[v10-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/3?use_travis_com=true
 
-[v6-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/5?use_travis_com=true
-[v8-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/6?use_travis_com=true
-[v9-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/7?use_travis_com=true
-[v10-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/8?use_travis_com=true
+[v6-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/4?use_travis_com=true
+[v8-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/5?use_travis_com=true
+[v10-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/6?use_travis_com=true
 
-[master-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/9?use_travis_com=true
-[canary-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/10?use_travis_com=true
+[master-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/7?use_travis_com=true
+[canary-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/8?use_travis_com=true


### PR DESCRIPTION
Since v9.x is EOL, we can remove it from our CI matrix. I also added names to our Travis jobs and reorganized `.travis.yml` (inspired on https://github.com/elastic/apm-agent-nodejs/blob/09316fa7c33330b7264d376ab219e85dd384a97a/.travis.yml#L184-L264).