### PR TITLE
src: inspect properties with descriptor details

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -510,10 +510,7 @@ inline bool DescriptorArray::IsConstFieldDetails(Smi details) {
   }
 
   // node.js >= 8
-  return (details.GetValue() &
-          v8()->descriptor_array()->kPropertyAttributesMask) ==
-         (v8()->descriptor_array()->kPropertyAttributesEnum_READ_ONLY
-          << v8()->descriptor_array()->kPropertyAttributesShift);
+  return false;
 }
 
 inline bool DescriptorArray::IsDoubleField(Smi details) {

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -476,6 +476,18 @@ inline Value DescriptorArray::GetValue(int index, Error& err) {
                     err);
 }
 
+inline bool DescriptorArray::IsDescriptorDetails(Smi details) {
+  // node.js <= 7
+  if (v8()->descriptor_array()->kPropertyTypeMask != -1) {
+    return false;
+  }
+
+  // node.js >= 8
+  return (details.GetValue() &
+          v8()->descriptor_array()->kPropertyLocationMask) ==
+         (v8()->descriptor_array()->kPropertyLocationEnum_kDescriptor
+          << v8()->descriptor_array()->kPropertyLocationShift);
+}
 inline bool DescriptorArray::IsFieldDetails(Smi details) {
   // node.js <= 7
   if (v8()->descriptor_array()->kPropertyTypeMask != -1) {

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -10,9 +10,9 @@
 namespace llnode {
 namespace v8 {
 
-using lldb::addr_t;
 using lldb::SBError;
 using lldb::SBTarget;
+using lldb::addr_t;
 
 static std::string kConstantPrefix = "v8dbg_";
 
@@ -1516,7 +1516,8 @@ std::string JSObject::InspectDescriptors(Map map, Error& err) {
     res += "    ." + key.ToString(err) + "=";
     if (err.Fail()) return std::string();
 
-    if (descriptors.IsConstFieldDetails(details) || descriptors.IsDescriptorDetails(details)) {
+    if (descriptors.IsConstFieldDetails(details) ||
+        descriptors.IsDescriptorDetails(details)) {
       Value value;
 
       value = descriptors.GetValue(i, err);
@@ -1665,7 +1666,8 @@ std::vector<std::pair<Value, Value>> JSObject::DescriptorEntries(Map map,
     Value key = descriptors.GetKey(i, err);
     if (err.Fail()) continue;
 
-    if (descriptors.IsConstFieldDetails(details)) {
+    if (descriptors.IsConstFieldDetails(details) ||
+        descriptors.IsDescriptorDetails(details)) {
       Value value;
 
       value = descriptors.GetValue(i, err);
@@ -1871,7 +1873,8 @@ Value JSObject::GetDescriptorProperty(std::string key_name, Map map,
     // Found the right key, get the value.
     if (err.Fail()) return Value();
 
-    if (descriptors.IsConstFieldDetails(details)) {
+    if (descriptors.IsConstFieldDetails(details) ||
+        descriptors.IsDescriptorDetails(details)) {
       Value value;
 
       value = descriptors.GetValue(i, err);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1516,7 +1516,7 @@ std::string JSObject::InspectDescriptors(Map map, Error& err) {
     res += "    ." + key.ToString(err) + "=";
     if (err.Fail()) return std::string();
 
-    if (descriptors.IsConstFieldDetails(details)) {
+    if (descriptors.IsConstFieldDetails(details) || descriptors.IsDescriptorDetails(details)) {
       Value value;
 
       value = descriptors.GetValue(i, err);
@@ -1524,14 +1524,6 @@ std::string JSObject::InspectDescriptors(Map map, Error& err) {
 
       res += value.Inspect(&options, err);
       if (err.Fail()) return std::string();
-      continue;
-    }
-
-    // Skip non-fields for now
-    if (!descriptors.IsFieldDetails(details)) {
-      Error::PrintInDebugMode("Unknown field Type %" PRId64,
-                              details.GetValue());
-      res += "<unknown field type>";
       continue;
     }
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -363,6 +363,7 @@ class DescriptorArray : public FixedArray {
   inline Value GetValue(int index, Error& err);
 
   inline bool IsFieldDetails(Smi details);
+  inline bool IsDescriptorDetails(Smi details);
   inline bool IsConstFieldDetails(Smi details);
   inline bool IsDoubleField(Smi details);
   inline int64_t FieldIndex(Smi details);


### PR DESCRIPTION
When the PropertyLocation of the details of a JSObject property is
kDescriptor, we can just get the descriptor from the descriptors array
and inspect it. This solves several fields being resolved as
`<unknown field type>`.

Fixes: https://github.com/nodejs/llnode/issues/198
Ref: https://github.com/nodejs/llnode/issues/209