### PR TITLE
test: increase Linux test coverage

### DIFF
--- a/test/addon/jsapi-test.js
+++ b/test/addon/jsapi-test.js
@@ -15,9 +15,6 @@ tape('llnode API', (t) => {
   if (process.env.LLNODE_CORE && process.env.LLNODE_NODE_EXE) {
     test(process.env.LLNODE_NODE_EXE, process.env.LLNODE_CORE, t);
     t.end();
-  } else if (process.platform === 'linux') {
-    t.skip('No `process save-core` on linux');
-    t.end();
   } else {
     common.saveCore({
       scenario: 'inspect-scenario.js'

--- a/test/common.js
+++ b/test/common.js
@@ -232,11 +232,7 @@ function saveCoreLLDB(scenario, core, cb) {
   });
 }
 
-function saveCoreLinux(executable, scenario, core, cb) {
-  const cmd = `ulimit -c unlimited && ${executable} ` +
-              `--abort_on_uncaught_exception --expose_externalize_string ` +
-              `${path.join(exports.fixturesDir, scenario)}; ` +
-              `mv ./core ${core}`;
+function spawnWithTimeout(cmd, cb) {
   const proc = spawn(cmd, {
     shell: true,
     stdio: ['pipe', 'pipe', 'pipe'] });
@@ -253,6 +249,16 @@ function saveCoreLinux(executable, scenario, core, cb) {
   proc.on('exit', (status) => {
     clearTimeout(timeout);
     cb(null);
+  });
+}
+
+function saveCoreLinux(executable, scenario, core, cb) {
+  const cmd = `ulimit -c unlimited && ${executable} ` +
+              `--abort_on_uncaught_exception --expose_externalize_string ` +
+              `${path.join(exports.fixturesDir, scenario)}; `;
+  spawnWithTimeout(cmd, () => {
+    // FIXME (mmarchini): Should also handle different core system settings.
+    spawnWithTimeout(`mv ./core ${core}`, cb);
   });
 }
 

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -10,9 +10,6 @@ tape('v8 findrefs and friends', (t) => {
   // Use prepared core and executable to test
   if (process.env.LLNODE_CORE && process.env.LLNODE_NODE_EXE) {
     test(process.env.LLNODE_NODE_EXE, process.env.LLNODE_CORE, t);
-  } else if (process.platform === 'linux') {
-    t.skip('No `process save-core` on linux');
-    t.end();
   } else {
     common.saveCore({
       scenario: 'inspect-scenario.js'


### PR DESCRIPTION
Some tests (`test/addon/jsapi-test.js` and `test/plugin/scan-test.js`)
were not running on Linux because LLDB is not able to save core dumps on
that platform. These changes use a simpler approach to save core dumps
on Linux so these tests can also be run there.

Ref: https://github.com/nodejs/llnode/issues/209