### PR TITLE
src: show context objects within `findrefs`

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -612,6 +612,10 @@ void FindReferencesCmd::PrintReferences(SBCommandReturnObject& result,
       //    "\n", type, addr);
     }
   }
+
+  // Print references found directly inside Context objects
+  Error err;
+  scanner->PrintContextRefs(result, err);
 }
 
 
@@ -668,6 +672,45 @@ char** FindReferencesCmd::ParseScanOptions(char** cmd, ScanType* type) {
   return &cmd[optind - 1];
 }
 
+// Walk all contexts previously stored and print search_value_
+// reference if it exists. Not all values are associated with
+// a context object. It seems that Function-Local variables are
+// stored in the stack, and when some nested closure references
+// it is allocated in a Context object.
+void FindReferencesCmd::ReferenceScanner::PrintContextRefs(
+    SBCommandReturnObject& result, Error& err) {
+  ContextVector* contexts = llscan_->GetContexts();
+  v8::LLV8* v8 = llscan_->v8();
+
+  for (auto ctx : *contexts) {
+    Error err;
+    v8::HeapObject context_obj(v8, ctx);
+    v8::Context c(context_obj);
+    v8::Context::Locals locals(&c);
+
+    v8::HeapObject scope_obj(locals.ctx->GetScopeInfo(err));
+    if (err.Fail()) return;
+
+    v8::ScopeInfo scope(scope_obj);
+    for (v8::Context::Locals::Iterator it = locals.begin(); it != locals.end();
+         it++) {
+      if (err.Fail()) {
+        continue;
+      }
+      if ((*it).raw() == search_value_.raw()) {
+        v8::String _name = scope.ContextLocalName(
+            it.current, locals.param_count, locals.stack_count, err);
+        if (err.Fail()) return;
+
+        std::string name = _name.ToString(err);
+        if (err.Fail()) return;
+
+        result.Printf("0x%" PRIx64 ": Context.%s=0x%" PRIx64 "\n", c.raw(),
+                      name.c_str(), search_value_.raw());
+      }
+    }
+  }
+}
 
 void FindReferencesCmd::ReferenceScanner::PrintRefs(
     SBCommandReturnObject& result, v8::JSObject& js_obj, Error& err) {
@@ -1192,6 +1235,20 @@ uint64_t FindJSObjectsVisitor::Visit(uint64_t location, uint64_t word) {
 
   v8::HeapObject heap_object(v8_value);
   if (!heap_object.Check()) return address_byte_size_;
+
+  bool is_context = v8::Context::IsContext(llscan_->v8(), heap_object, err);
+  if (err.Fail()) {
+    return address_byte_size_;
+  }
+
+  if (is_context) {
+    ContextVector* contexts;
+    contexts = llscan_->GetContexts();
+
+    if (std::find(contexts->begin(), contexts->end(), word) == contexts->end())
+      contexts->push_back(word);
+    return address_byte_size_;
+  }
 
   v8::HeapObject map_object = heap_object.GetMap(err);
   if (err.Fail() || !map_object.Check()) return address_byte_size_;

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -686,20 +686,14 @@ void FindReferencesCmd::ReferenceScanner::PrintContextRefs(
     Error err;
     v8::HeapObject context_obj(v8, ctx);
     v8::Context c(context_obj);
-    v8::Context::Locals locals(&c);
 
-    v8::HeapObject scope_obj(locals.ctx->GetScopeInfo(err));
+    v8::Context::Locals locals(&c, err);
     if (err.Fail()) return;
 
-    v8::ScopeInfo scope(scope_obj);
     for (v8::Context::Locals::Iterator it = locals.begin(); it != locals.end();
          it++) {
-      if (err.Fail()) {
-        continue;
-      }
       if ((*it).raw() == search_value_.raw()) {
-        v8::String _name = scope.ContextLocalName(
-            it.current, locals.param_count, locals.stack_count, err);
+        v8::String _name = it.LocalName(err);
         if (err.Fail()) return;
 
         std::string name = _name.ToString(err);

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -13,6 +13,7 @@ namespace llnode {
 class LLScan;
 
 typedef std::vector<uint64_t> ReferencesVector;
+typedef std::vector<uint64_t> ContextVector;
 
 typedef std::map<uint64_t, ReferencesVector*> ReferencesByValueMap;
 typedef std::map<std::string, ReferencesVector*> ReferencesByPropertyMap;
@@ -89,6 +90,9 @@ class FindReferencesCmd : public CommandBase {
     virtual void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                            Error& err) {}
 
+    virtual void PrintContextRefs(lldb::SBCommandReturnObject& result,
+                                  Error& err) {}
+
     static const char* const property_reference_template;
     static const char* const array_reference_template;
   };
@@ -114,6 +118,9 @@ class FindReferencesCmd : public CommandBase {
                    Error& err) override;
     void PrintRefs(lldb::SBCommandReturnObject& result, v8::String& str,
                    Error& err) override;
+
+    void PrintContextRefs(lldb::SBCommandReturnObject& result,
+                          Error& err) override;
 
    private:
     LLScan* llscan_;
@@ -315,6 +322,7 @@ class LLScan {
     return references_by_value_[address];
   };
 
+  // References By Property
   inline bool AreReferencesByPropertyLoaded() {
     return references_by_property_.size() > 0;
   };
@@ -325,6 +333,7 @@ class LLScan {
     return references_by_property_[property];
   };
 
+  // References By String
   inline bool AreReferencesByStringLoaded() {
     return references_by_string_.size() > 0;
   };
@@ -334,6 +343,10 @@ class LLScan {
     }
     return references_by_string_[string_value];
   };
+
+  // Contexts
+  inline bool AreContextsLoaded() { return contexts_.size() > 0; };
+  inline ContextVector* GetContexts() { return &contexts_; }
 
   v8::LLV8* llv8_;
 
@@ -362,6 +375,7 @@ class LLScan {
   ReferencesByValueMap references_by_value_;
   ReferencesByPropertyMap references_by_property_;
   ReferencesByStringMap references_by_string_;
+  ContextVector contexts_;
 };
 
 }  // namespace llnode

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -397,6 +397,35 @@ class Context : public FixedArray {
   inline Value ContextSlot(int index, Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);
+  static inline bool IsContext(LLV8* v8, HeapObject heap_object, Error& err);
+
+  // Iterator class to walk all local references on a context
+  class Locals {
+   public:
+    class Iterator {
+     public:
+      Value operator*();
+      const Context::Locals::Iterator operator++(int);
+      bool operator!=(Context::Locals::Iterator that);
+
+      inline Iterator(int current, Context* ctx) : current(current), ctx(ctx){};
+
+     public:
+      int current;
+      Context* ctx;
+    };
+
+    Locals(Context* ctx_);
+
+    Iterator begin();
+    Iterator end();
+
+   public:
+    int local_count;
+    int param_count;
+    int stack_count;
+    Context* ctx;
+  };
 
  private:
   inline JSFunction Closure(Error& err);

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -70,15 +70,6 @@ function test(executable, core, t) {
   });
 
   sess.linesUntil(versionMark, (err, lines) => {
-    t.error(err)
-    // `target modules dump symtab` is used to check if
-    // constant `v8dbg_LastContextType` exists on the next
-    // test.
-    sess.send('target modules dump symtab');
-    sess.send('version');
-  });
-
-  sess.linesUntil(versionMark, (err, lines) => {
     t.error(err);
 
     // `class Deflate extends Zlib` makes instances show up as
@@ -93,11 +84,12 @@ function test(executable, core, t) {
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');
 
     // Test if LastContextType constat exists
-    let patt = new RegExp("v8dbg_LastContextType");
-    if (patt.test(lines.join('\n'))) {
+    sess.hasSymbol('v8dbg_LastContextType', (err, hasSymbol) => {
+      t.error(err)
+      if(hasSymbol)
         t.ok(/Context\.scopedAPI/.test(lines.join('\n')), 'Should find reference #4');
-    }
-    sess.quit();
-    t.end();
+      sess.quit();
+      t.end();
+    });
   });
 }

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -65,8 +65,16 @@ function test(executable, core, t) {
     }
     t.ok(found, 'Zlib should be in findjsinstances');
 
-    sess.send("target modules dump symtab");
     // Just a separator
+    sess.send('version');
+  });
+
+  sess.linesUntil(versionMark, (err, lines) => {
+    t.error(err)
+    // `target modules dump symtab` is used to check if
+    // constant `v8dbg_LastContextType` exists on the next
+    // test.
+    sess.send('target modules dump symtab');
     sess.send('version');
   });
 

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -65,6 +65,7 @@ function test(executable, core, t) {
     }
     t.ok(found, 'Zlib should be in findjsinstances');
 
+    sess.send("target modules dump symtab");
     // Just a separator
     sess.send('version');
   });
@@ -83,6 +84,11 @@ function test(executable, core, t) {
     t.ok(/Object\.holder/.test(lines.join('\n')), 'Should find reference #2');
     t.ok(/\(Array\)\[1\]/.test(lines.join('\n')), 'Should find reference #3');
 
+    // Test if LastContextType constat exists
+    let patt = new RegExp("v8dbg_LastContextType");
+    if (patt.test(lines.join('\n'))) {
+        t.ok(/Context\.scopedAPI/.test(lines.join('\n')), 'Should find reference #4');
+    }
     sess.quit();
     t.end();
   });


### PR DESCRIPTION
When using `findrefs` we should be able to get all references
for the given value, this includes `Context` objects.

Refs: https://github.com/nodejs/llnode/issues/195

Sample output:
![screenshot from 2018-09-04 16-10-51](https://user-images.githubusercontent.com/1836388/45052450-37d5b680-b05d-11e8-8e19-e9fdc4d747f0.png)
