### PR TITLE
src: run make format on all files

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -17,8 +17,6 @@
 
 namespace llnode {
 
-using lldb::eReturnStatusFailed;
-using lldb::eReturnStatusSuccessFinishResult;
 using lldb::SBCommandInterpreter;
 using lldb::SBCommandReturnObject;
 using lldb::SBDebugger;
@@ -30,6 +28,8 @@ using lldb::SBSymbol;
 using lldb::SBTarget;
 using lldb::SBThread;
 using lldb::SBValue;
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
 
 
 bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -18,8 +18,6 @@
 namespace llnode {
 
 using lldb::ByteOrder;
-using lldb::eReturnStatusFailed;
-using lldb::eReturnStatusSuccessFinishResult;
 using lldb::SBCommandReturnObject;
 using lldb::SBDebugger;
 using lldb::SBError;
@@ -27,6 +25,8 @@ using lldb::SBExpressionOptions;
 using lldb::SBStream;
 using lldb::SBTarget;
 using lldb::SBValue;
+using lldb::eReturnStatusFailed;
+using lldb::eReturnStatusSuccessFinishResult;
 
 const char* const
     FindReferencesCmd::ObjectScanner::property_reference_template =

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -13,7 +13,6 @@ namespace llnode {
 namespace v8 {
 namespace constants {
 
-using lldb::addr_t;
 using lldb::SBAddress;
 using lldb::SBError;
 using lldb::SBProcess;
@@ -21,6 +20,7 @@ using lldb::SBSymbol;
 using lldb::SBSymbolContext;
 using lldb::SBSymbolContextList;
 using lldb::SBTarget;
+using lldb::addr_t;
 
 void Module::Assign(SBTarget target, Common* common) {
   loaded_ = false;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1103,7 +1103,10 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
   HeapObject heap_previous = HeapObject(previous);
   if (heap_previous.Check()) {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(previous)=0x%016" PRIx64).c_str(), previous.raw());
+    snprintf(
+        tmp, sizeof(tmp),
+        (options->get_indent_spaces() + "(previous)=0x%016" PRIx64).c_str(),
+        previous.raw());
     res += std::string(tmp) + ":<Context>,";
   }
 
@@ -1113,8 +1116,10 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
     JSFunction closure = Closure(err);
     if (err.Fail()) return std::string();
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(closure)=0x%016" PRIx64 " {").c_str(),
-             closure.raw());
+    snprintf(
+        tmp, sizeof(tmp),
+        (options->get_indent_spaces() + "(closure)=0x%016" PRIx64 " {").c_str(),
+        closure.raw());
     res += tmp;
 
     InspectOptions closure_options;
@@ -1122,13 +1127,16 @@ std::string Context::Inspect(InspectOptions* options, Error& err) {
     if (err.Fail()) return std::string();
   } else {
     char tmp[128];
-    snprintf(tmp, sizeof(tmp), (options->get_indent_spaces() + "(scope_info)=0x%016" PRIx64).c_str(),
-             scope.raw());
+    snprintf(
+        tmp, sizeof(tmp),
+        (options->get_indent_spaces() + "(scope_info)=0x%016" PRIx64).c_str(),
+        scope.raw());
 
     res += std::string(tmp) + ":<ScopeInfo";
 
     Error function_name_error;
-    HeapObject maybe_function_name = scope.MaybeFunctionName(function_name_error);
+    HeapObject maybe_function_name =
+        scope.MaybeFunctionName(function_name_error);
 
     if (function_name_error.Success()) {
       res += ": for function " + String(maybe_function_name).ToString(err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -396,7 +396,7 @@ class Context : public FixedArray {
   inline T GetEmbedderData(int64_t index, Error& err);
   inline Value ContextSlot(int index, Error& err);
 
-  std::string Inspect(InspectOptions *options, Error& err);
+  std::string Inspect(InspectOptions* options, Error& err);
 
  private:
   inline JSFunction Closure(Error& err);


### PR DESCRIPTION
Apparently we forgot to run `make format` on a few commits lately. This
commit was just a `make format` run to fix some nits. clang-format
version: `clang-format version 5.0.1 (tags/RELEASE_501/final)`