### PR TITLE
src: print stack for error objects

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -44,7 +44,6 @@ inline bool HeapObject::Check() const {
   return (raw() & v8()->heap_obj()->kTagMask) == v8()->heap_obj()->kTag;
 }
 
-
 int64_t HeapObject::LeaField(int64_t off) const {
   return raw() - v8()->heap_obj()->kTag + off;
 }
@@ -81,6 +80,21 @@ inline int64_t HeapObject::GetType(Error& err) {
 
   Map map(obj);
   return map.GetType(err);
+}
+
+
+inline bool HeapObject::ISJSErrorType(Error& err) {
+  int64_t type = GetType(err);
+  if (type == v8()->types()->kJSErrorType) return true;
+
+  // NOTE (mmarchini): We don't have a JSErroType constant on Node.js v6.x,
+  // thus we try to guess if the object is an Error object by checking if its
+  // name is Error. Should work most of the time.
+  if (!JSObject::IsObjectType(v8(), type)) return false;
+  JSObject obj(this);
+  if (obj.GetTypeName(err) != "Error" || err.Fail()) return false;
+
+  return true;
 }
 
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -44,6 +44,7 @@ inline bool HeapObject::Check() const {
   return (raw() & v8()->heap_obj()->kTagMask) == v8()->heap_obj()->kTag;
 }
 
+
 int64_t HeapObject::LeaField(int64_t off) const {
   return raw() - v8()->heap_obj()->kTag + off;
 }
@@ -83,18 +84,19 @@ inline int64_t HeapObject::GetType(Error& err) {
 }
 
 
-inline bool HeapObject::ISJSErrorType(Error& err) {
+inline bool HeapObject::IsJSErrorType(Error& err) {
   int64_t type = GetType(err);
+  if (err.Fail()) return false;
   if (type == v8()->types()->kJSErrorType) return true;
 
-  // NOTE (mmarchini): We don't have a JSErroType constant on Node.js v6.x,
+  // NOTE (mmarchini): We don't have a JSErrorType constant on Node.js v6.x,
   // thus we try to guess if the object is an Error object by checking if its
   // name is Error. Should work most of the time.
   if (!JSObject::IsObjectType(v8(), type)) return false;
-  JSObject obj(this);
-  if (obj.GetTypeName(err) != "Error" || err.Fail()) return false;
 
-  return true;
+  JSObject obj(this);
+  std::string type_name = obj.GetTypeName(err);
+  return err.Success() && type_name == "Error";
 }
 
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -827,7 +827,7 @@ std::string HeapObject::Inspect(InspectOptions* options, Error& err) {
     return pre + m.Inspect(options, err);
   }
 
-  if (ISJSErrorType(err)) {
+  if (IsJSErrorType(err)) {
     JSError error(this);
     return pre + error.Inspect(options, err);
   }
@@ -1564,7 +1564,7 @@ std::string JSError::InspectAllProperties(InspectOptions* options, Error& err) {
 
     if (err.Fail()) {
       Error::PrintInDebugMode(
-          "Couldn't find a symbol property in the Error objcet.");
+          "Couldn't find a symbol property in the Error object.");
       return res;
     }
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -114,6 +114,8 @@ class HeapObject : public Value {
   std::string ToString(Error& err);
   std::string Inspect(InspectOptions* options, Error& err);
   std::string GetTypeName(Error& err);
+
+  inline bool ISJSErrorType(Error& err);
 };
 
 class Map : public HeapObject {
@@ -257,6 +259,7 @@ class JSObject : public HeapObject {
   inline HeapObject Elements(Error& err);
 
   std::string Inspect(InspectOptions* options, Error& err);
+  virtual std::string InspectAllProperties(InspectOptions* options, Error& err);
   std::string InspectInternalFields(Error& err);
   std::string InspectProperties(Error& err);
 
@@ -288,6 +291,14 @@ class JSObject : public HeapObject {
   std::vector<std::pair<Value, Value>> DescriptorEntries(Map map, Error& err);
   Value GetDictionaryProperty(std::string key_name, Error& err);
   Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
+};
+
+class JSError : public JSObject {
+ public:
+  V8_VALUE_DEFAULT_METHODS(JSError, JSObject);
+
+  std::string InspectAllProperties(InspectOptions* options,
+                                   Error& err) override;
 };
 
 class JSArray : public JSObject {
@@ -583,6 +594,7 @@ class LLV8 {
   friend class ThinString;
   friend class HeapNumber;
   friend class JSObject;
+  friend class JSError;
   friend class JSArray;
   friend class FixedArrayBase;
   friend class FixedArray;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -115,7 +115,7 @@ class HeapObject : public Value {
   std::string Inspect(InspectOptions* options, Error& err);
   std::string GetTypeName(Error& err);
 
-  inline bool ISJSErrorType(Error& err);
+  inline bool IsJSErrorType(Error& err);
 };
 
 class Map : public HeapObject {

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -151,6 +151,12 @@ const hashMapTests = {
         let errnoMatch = lines.match(/errno=<Smi: 1>/i);
         t.ok(errnoMatch, 'hashmap.error.errno should be 1');
 
+        let stackMatch  = lines.match(/error stack {/i);
+        t.ok(stackMatch, 'Error object should have an error stack');
+
+        let closureMatch = lines.match(/0x[0-9a-f]+:<function: closure/i);
+        t.ok(closureMatch, 'closure frame should be in the error stack');
+
         cb(null);
       });
     }


### PR DESCRIPTION
Error objects have a .stack property, which is actually an accessor. The
stack is stored in a unnamed symbol property and converted to a string
when .stack is accessed in JavaScript. This patch implements the
accessor behavior to print the error stack when inspecting an Error
object.

Fixes: https://github.com/nodejs/llnode/issues/218