### PR TITLE
Show a limited number of entries

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -423,8 +423,14 @@ bool PluginInitialize(SBDebugger d) {
 
   v8.AddCommand("findjsinstances", new llnode::FindInstancesCmd(&llscan, false),
                 "List every object with the specified type name.\n"
-                "Use -v or --verbose to display detailed `v8 inspect` output "
+                "Flags:\n\n"
+                " * -v, --verbose                  - display detailed `v8 "
+                "inspect` output "
                 "for each object.\n"
+                " * -n <num>  --output-limit <num> - limit the number of "
+                "entries displayed "
+                "to `num` (use 0 to show all). To get next page repeat command "
+                "or press [ENTER].\n"
                 "Accepts the same options as `v8 inspect`");
 
   interpreter.AddCommand("findjsinstances",

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -35,7 +35,6 @@ const char* const
 const char* const FindReferencesCmd::ObjectScanner::array_reference_template =
     "0x%" PRIx64 ": %s[%" PRId64 "]=0x%" PRIx64 "\n";
 
-
 const char* const
     FindReferencesCmd::StringScanner::property_reference_template =
         "0x%" PRIx64 ": %s.%s=0x%" PRIx64 " '%s'\n";
@@ -283,7 +282,9 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
       std::string res = v8_value.Inspect(&inspect_options, err);
       result.Printf("%s\n", res.c_str());
     }
-    result.Printf("..........\n");
+    if (it != t->GetInstances().end()) {
+      result.Printf("..........\n");
+    }
     result.Printf("(Showing %d to %d of %d instances)\n", initial_p_offset + 1,
                   final_p_offset, pagination_.total_entries);
 

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -7,6 +7,7 @@
 #include <cinttypes>
 #include <fstream>
 #include <vector>
+#include <iostream>
 
 #include <lldb/API/SBExpressionOptions.h>
 
@@ -51,6 +52,7 @@ char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options) {
       {"print-source", no_argument, nullptr, 's'},
       {"verbose", no_argument, nullptr, 'v'},
       {"detailed", no_argument, nullptr, 'd'},
+      {"output-limit", required_argument, nullptr, 'n'},
       {nullptr, 0, nullptr, 0}};
 
   int argc = 1;
@@ -68,7 +70,7 @@ char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options) {
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, args, "Fmsdvl:", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fmsdvln:", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {
@@ -88,6 +90,10 @@ char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options) {
       case 'v':
         options->detailed = true;
         break;
+      case 'n': {
+        int limit = strtol(optarg, nullptr, 10);
+        options->output_limit = limit && limit > 0 ? limit : 0;
+      } break;
       default:
         continue;
     }
@@ -221,6 +227,7 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
 
   inspect_options.detailed = detailed_;
 
+  // Use same options as inspect?
   char** start = ParseInspectOptions(cmd, &inspect_options);
 
   std::string full_cmd;
@@ -230,15 +237,55 @@ bool FindInstancesCmd::DoExecute(SBDebugger d, char** cmd,
 
   TypeRecordMap::iterator instance_it =
       llscan_->GetMapsToInstances().find(type_name);
+
   if (instance_it != llscan_->GetMapsToInstances().end()) {
+
+
     TypeRecord* t = instance_it->second;
-    for (std::set<uint64_t>::iterator it = t->GetInstances().begin();
-         it != t->GetInstances().end(); ++it) {
+
+    // Update pagination options
+    if (full_cmd != pagination_.command ||
+        inspect_options.output_limit != pagination_.output_limit) {
+      pagination_.total_entries = t->GetInstanceCount();
+      pagination_.command = full_cmd;
+      pagination_.current_page = 0;
+      pagination_.output_limit = inspect_options.output_limit;
+    } else {
+      if (pagination_.output_limit <= 0 ||
+          (pagination_.current_page + 1) * pagination_.output_limit >
+              pagination_.total_entries) {
+        pagination_.current_page = 0;
+      } else {
+        pagination_.current_page++;
+      }
+    }
+
+    int initial_p_offset =
+        (pagination_.current_page * inspect_options.output_limit);
+    int final_p_offset =
+        initial_p_offset +
+        std::min(pagination_.output_limit,
+                 pagination_.total_entries -
+                     pagination_.current_page * pagination_.output_limit);
+    if (final_p_offset <= 0) {
+      final_p_offset = pagination_.total_entries;
+    }
+
+    std::set<uint64_t>::iterator it =
+        pagination_.current_page == 0
+            ? t->GetInstances().begin()
+            : std::next(t->GetInstances().begin(), initial_p_offset);
+    for (; it != t->GetInstances().end() &&
+           it != (std::next(t->GetInstances().begin(), final_p_offset));
+         ++it) {
       Error err;
       v8::Value v8_value(llscan_->v8(), *it);
       std::string res = v8_value.Inspect(&inspect_options, err);
       result.Printf("%s\n", res.c_str());
     }
+    result.Printf("..........\n");
+    result.Printf("(Showing %d to %d of %d instances)\n", initial_p_offset + 1,
+                  final_p_offset, pagination_.total_entries);
 
   } else {
     result.Printf("No objects found with type name %s\n", type_name.c_str());

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -19,6 +19,19 @@ typedef std::map<uint64_t, ReferencesVector*> ReferencesByValueMap;
 typedef std::map<std::string, ReferencesVector*> ReferencesByPropertyMap;
 typedef std::map<std::string, ReferencesVector*> ReferencesByStringMap;
 
+
+// New type defining pagination options
+// It should be feasible to use it to any commands that output
+// a list of information
+typedef struct cmd_pagination {
+  cmd_pagination()
+      : total_entries(0), current_page(0), output_limit(0), command(""){};
+  int total_entries;
+  int current_page;
+  int output_limit;
+  std::string command;
+} cmd_pagination_t;
+
 char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options);
 
 class FindObjectsCmd : public CommandBase {
@@ -39,7 +52,8 @@ class FindObjectsCmd : public CommandBase {
 class FindInstancesCmd : public CommandBase {
  public:
   FindInstancesCmd(LLScan* llscan, bool detailed)
-      : llscan_(llscan), detailed_(detailed) {}
+      : llscan_(llscan), detailed_(detailed) {
+  }
   ~FindInstancesCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
@@ -48,6 +62,7 @@ class FindInstancesCmd : public CommandBase {
  private:
   LLScan* llscan_;
   bool detailed_;
+  cmd_pagination_t pagination_;
 };
 
 class NodeInfoCmd : public CommandBase {

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -23,14 +23,12 @@ typedef std::map<std::string, ReferencesVector*> ReferencesByStringMap;
 // New type defining pagination options
 // It should be feasible to use it to any commands that output
 // a list of information
-typedef struct cmd_pagination {
-  cmd_pagination()
-      : total_entries(0), current_page(0), output_limit(0), command(""){};
-  int total_entries;
-  int current_page;
-  int output_limit;
-  std::string command;
-} cmd_pagination_t;
+struct cmd_pagination_t {
+  int total_entries = 0;
+  int current_page = 0;
+  int output_limit = 0;
+  std::string command = "";
+};
 
 char** ParseInspectOptions(char** cmd, v8::Value::InspectOptions* options);
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -45,7 +45,8 @@ class Value {
           print_map(false),
           print_source(false),
           length(kLength),
-          indent_depth(1) {}
+          indent_depth(1),
+          output_limit(0) {}
 
     static const unsigned int kLength = 16;
     static const unsigned int kIndentSize = 2;
@@ -58,6 +59,7 @@ class Value {
     bool print_source;
     unsigned int length;
     unsigned int indent_depth;
+    int output_limit;
   };
 
   Value(const Value& v) = default;

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -24,6 +24,7 @@ function closure() {
     this.hashmap = {};
   }
 
+
   Class.prototype.method = function method() {
     throw new Error('Uncaught');
   };
@@ -75,6 +76,13 @@ function closure() {
   c.hashmap.scoped = function name() {
     return scopedVar + outerVar + scopedAPI + scopedArray;
   };
+
+  function Class_B() {
+    this.name = "Class B";
+  }
+
+  const arr = new Array();
+  for(let i=0; i < 10; i++) arr.push(new Class_B());
 
   c.method();
 }

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -46,8 +46,40 @@ function test(executable, core, t) {
     t.ok(/3 +0 Class: x, y, hashmap/.test(lines.join('\n')),
          '"Class: x, y, hashmap" should be in findjsobjects -d');
 
-    sess.send('v8 findjsinstances Zlib');
+    sess.send('v8 findjsinstances Class_B')
     // Just a separator
+    sess.send('version');
+  });
+
+  sess.linesUntil(versionMark, (err, lines) => {
+    t.error(err);
+
+    t.ok((lines.join('\n').match(/<Object: Class_B>/g)).length == 10, 'Should show 10 instances');
+    t.ok(/\(Showing 1 to 10 of 10 instances\)/.test(lines.join('\n')), 'Should show 1 to 10 ');
+
+    sess.send('v8 findjsinstances -n 5 Class_B');
+    sess.send('version');
+  });
+
+  sess.linesUntil(versionMark, (err, lines) => {
+    t.error(err);
+
+    t.ok((lines.join('\n').match(/<Object: Class_B>/g)).length == 5, 'Should show 5 instances');
+    t.ok(/\.\.\.\.\.\.\.\.\.\./.test(lines.join('\n')), 'Should show that more instances are available');
+    t.ok(/\(Showing 1 to 5 of 10 instances\)/.test(lines.join('\n')), 'Should show 1 to 5 ');
+
+    sess.send('v8 findjsinstances -n 5 Class_B');
+    sess.send('version');
+  });
+
+  sess.linesUntil(versionMark, (err, lines) => {
+    t.error(err);
+
+    t.ok((lines.join('\n').match(/<Object: Class_B>/g)).length == 5, 'Should show 5 instances');
+    t.notOk(/\.\.\.\.\.\.\.\.\.\./.test(lines.join('\n')), 'Should not show ellipses');
+    t.ok(/\(Showing 6 to 10 of 10 instances\)/.test(lines.join('\n')), 'Should show 6 to 10 ');
+
+    sess.send('v8 findjsinstances Zlib');
     sess.send('version');
   });
 


### PR DESCRIPTION
Added a new option to `findjsinstances` that allow user to limit the number of entries shown. Command would be as follow
```
v8 findjsinstances -n <num> <search>
```
First `num` entries will be displayed, to see the following `num` instances user would just repeat the same `num` and `search`, or just press [ENTER] as it repeats the last command. Once we reached the last "page" it begins to show from the first entry again.

I created a simple example to show usage:
https://asciinema.org/a/X04QMdeyWlDY1DBWeCDBNVUry