### PR TITLE
src: fix build on older compilers (gcc 4.8)

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -240,6 +240,29 @@ inline bool JSObject::IsObjectType(LLV8* v8, int64_t type) {
          type == v8->types()->kJSSpecialAPIObjectType;
 }
 
+inline std::string JSObject::GetName(Error& err) {
+  v8::HeapObject map_obj = GetMap(err);
+  if (err.Fail()) return std::string();
+
+  v8::Map map(map_obj);
+  v8::HeapObject constructor_obj = map.Constructor(err);
+  if (err.Fail()) return std::string();
+
+  int64_t constructor_type = constructor_obj.GetType(err);
+  if (err.Fail()) return std::string();
+
+  if (constructor_type != v8()->types()->kJSFunctionType) {
+    return "no constructor";
+  }
+
+  v8::JSFunction constructor(constructor_obj);
+
+  std::string name = constructor.Name(err);
+  if (err.Fail()) return std::string();
+
+  return name;
+}
+
 template <class T>
 inline T JSObject::GetInObjectValue(int64_t size, int index, Error& err) {
   return LoadFieldValue<T>(size + index * v8()->common()->kPointerSize, err);

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -237,6 +237,8 @@ class JSObject : public HeapObject {
    */
   std::vector<std::pair<Value, Value>> Entries(Error& err);
 
+  inline std::string GetName(Error& err);
+
   Value GetProperty(std::string key_name, Error& err);
   int64_t GetArrayLength(Error& err);
   Value GetArrayElement(int64_t pos, Error& err);

--- a/src/printer.h
+++ b/src/printer.h
@@ -48,9 +48,6 @@ class Printer {
   std::string StringifyInternalFields(v8::JSObject js_obj, Error& err);
   std::string StringifyProperties(v8::JSObject js_obj, Error& err);
 
-  template <typename T>
-  std::string StringifyAllProperties(T value, Error& err);
-
   std::string StringifyElements(v8::JSObject js_obj, Error& err);
   std::string StringifyElements(v8::JSObject js_obj, int64_t length,
                                 Error& err);


### PR DESCRIPTION
Build broke on older compilers (such as gcc 4.8) after
https://github.com/nodejs/llnode/pull/246 landed. The issue is related
to using default values for templates in the ::Stringiy definition. This
commit makes minimal changes to fix the build while keeping
functionality intact. A follow-up refactor of Stringify<JSError> is
required.