### PR TITLE
src: refactor JSError stringifier

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -722,6 +722,18 @@ inline bool JSArrayBuffer::WasNeutered(Error& err) {
   return field != 0;
 }
 
+inline std::string JSError::stack_trace_property() {
+  // TODO (mmarchini): once we have Symbol support we'll need to search for
+  // <unnamed symbol>, since the stack symbol doesn't have an external name.
+  // In the future we can add postmortem metadata on V8 regarding existing
+  // symbols, but for now we'll use an heuristic to find the stack in the
+  // error object.
+  return v8()->types()->kSymbolType != -1 ? "Symbol()" : "<non-string>";
+}
+
+inline int StackTrace::GetFrameCount() { return len_; }
+
+
 #undef ACCESSOR
 
 }  // namespace v8

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1274,7 +1274,9 @@ StackTrace::StackTrace(JSArray frame_array, Error& err)
           len_, frame_array_.GetArrayLength(err));
       len_ = -1;
       multiplier_ = -1;
+      return;
     }
+    len_ = (frame_array_.GetArrayLength(err) - 1) / multiplier_;
   }
 }
 

--- a/src/printer.h
+++ b/src/printer.h
@@ -55,6 +55,7 @@ class Printer {
   std::string StringifyDescriptors(v8::JSObject js_obj, v8::Map map,
                                    Error& err);
 
+  std::string StringifyJSObjectFields(v8::JSObject js_obj, Error& err);
 
   // FixedArray Specific Methods
   std::string StringifyContents(v8::FixedArray fixed_array, int length,


### PR DESCRIPTION
Essentially move all the logic related to how JSError stack traces are
accessible to llv8 files, breaking this logic into smaller functions.
Also moved the chunk of code related to printing JSObject properties to
its own function, to allow reuse between JSError and JSObject
stringifiers.