### PR TITLE
src: move JSDate "ToString" logic to JSDate class

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -279,6 +279,18 @@ ACCESSOR(JSRegExp, GetSource, js_regexp()->kSourceOffset, String)
 
 ACCESSOR(JSDate, GetValue, js_date()->kValueOffset, Value)
 
+bool JSDate::IsSmi(Error& err) {
+  v8::Value val(GetValue(err));
+  v8::Smi smi(val);
+  return smi.Check();
+}
+
+bool JSDate::IsHeapNumber(Error& err) {
+  v8::Value val(GetValue(err));
+  v8::HeapNumber heap_number(val);
+  return heap_number.Check();
+}
+
 bool String::IsString(LLV8* v8, HeapObject heap_object, Error& err) {
   if (!heap_object.Check()) return false;
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -279,18 +279,6 @@ ACCESSOR(JSRegExp, GetSource, js_regexp()->kSourceOffset, String)
 
 ACCESSOR(JSDate, GetValue, js_date()->kValueOffset, Value)
 
-bool JSDate::IsSmi(Error& err) {
-  v8::Value val(GetValue(err));
-  v8::Smi smi(val);
-  return smi.Check();
-}
-
-bool JSDate::IsHeapNumber(Error& err) {
-  v8::Value val(GetValue(err));
-  v8::HeapNumber heap_number(val);
-  return heap_number.Check();
-}
-
 bool String::IsString(LLV8* v8, HeapObject heap_object, Error& err) {
   if (!heap_object.Check()) return false;
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -684,8 +684,8 @@ std::string JSDate::ToString(Error& err) {
 
   // Check if it is SMI
   // e.g: date = new Date(1)
-  if (IsSmi(err)) {
-    v8::Smi smi(val);
+  v8::Smi smi(val);
+  if (smi.Check()) {
     std::string s = smi.ToString(err);
     if (err.Fail()) return "";
     return s;
@@ -693,8 +693,8 @@ std::string JSDate::ToString(Error& err) {
 
   // Check if it is HeapNumber
   // e.g: date = new Date()
-  if (IsHeapNumber(err)) {
-    v8::HeapNumber hn(val);
+  v8::HeapNumber hn(val);
+  if (hn.Check()) {
     std::string s = hn.ToString(true, err);
     if (err.Fail()) return "";
     return s;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -679,6 +679,31 @@ std::string HeapNumber::ToString(bool whole, Error& err) {
   return buf;
 }
 
+std::string JSDate::ToString(Error& err) {
+  v8::Value val(GetValue(err));
+
+  // Check if it is SMI
+  // e.g: date = new Date(1)
+  if (IsSmi(err)) {
+    v8::Smi smi(val);
+    std::string s = smi.ToString(err);
+    if (err.Fail()) return "";
+    return s;
+  }
+
+  // Check if it is HeapNumber
+  // e.g: date = new Date()
+  if (IsHeapNumber(err)) {
+    v8::HeapNumber hn(val);
+    std::string s = hn.ToString(true, err);
+    if (err.Fail()) return "";
+    return s;
+  }
+
+  Error::PrintInDebugMode("JSDate is not a Smi neither a HeapNumber");
+  return "";
+}
+
 
 std::string Symbol::ToString(Error& err) {
   if (!String::IsString(v8(), Name(err), err)) {

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -373,6 +373,9 @@ class JSDate : public JSObject {
   V8_VALUE_DEFAULT_METHODS(JSDate, JSObject);
 
   inline Value GetValue(Error& err);
+  inline bool IsSmi(Error& err);
+  inline bool IsHeapNumber(Error& err);
+  std::string ToString(Error& err);
 };
 
 class FixedArrayBase : public HeapObject {

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -373,8 +373,6 @@ class JSDate : public JSObject {
   V8_VALUE_DEFAULT_METHODS(JSDate, JSObject);
 
   inline Value GetValue(Error& err);
-  inline bool IsSmi(Error& err);
-  inline bool IsHeapNumber(Error& err);
   std::string ToString(Error& err);
 };
 

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -1,5 +1,6 @@
 #include <cinttypes>
 #include <sstream>
+#include <iostream>
 
 #include "deps/rang/include/rang.hpp"
 #include "src/llv8-inl.h"
@@ -136,34 +137,10 @@ std::string Printer::Stringify(v8::JSFunction js_function, Error& err) {
 
 template <>
 std::string Printer::Stringify(v8::JSDate js_date, Error& err) {
-  std::string pre = "<JSDate: ";
-
-  v8::Value val = js_date.GetValue(err);
-
-  v8::Smi smi(val);
-  if (smi.Check()) {
-    std::string s = smi.ToString(err);
-    if (err.Fail()) {
-      return pre + ">";
-    }
-
-    return pre + s + ">";
-  }
-
-  v8::HeapNumber hn(val);
-  if (hn.Check()) {
-    std::string s = hn.ToString(true, err);
-    if (err.Fail()) {
-      return pre + ">";
-    }
-    return pre + s + ">";
-  }
-
-  double d = static_cast<double>(val.raw());
-  char buf[128];
-  snprintf(buf, sizeof(buf), "%f", d);
-
-  return pre + ">";
+  std::stringstream ss;
+  ss << rang::fg::yellow << "<JSDate: " + js_date.ToString(err) + ">"
+     << rang::fg::reset;
+  return ss.str();
 }
 
 template <>

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -74,6 +74,9 @@ function closure() {
   let scopedAPI = zlib.createDeflate()._handle;
   let scopedArray = [ 0, scopedAPI ];
 
+  c.hashmap['date_1'] = new Date('2000-01-01');
+  c.hashmap['date_2'] = new Date(1);
+
   exports.holder = scopedAPI;
 
   c.hashmap.scoped = function name() {

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -345,7 +345,18 @@ const hashMapTests = {
         cb(null);
       });
     }
+  },
+  // .date_1=<JSDate: >
+  'date_1': {
+    re: /\.date_1=0x[0-9a-f]+:<JSDate: 946684800000\.000000>/,
+    desc: ".date_2 JSDate element"
+  },
+  // .date_2=<JSDate: 1>
+  'date_2' : {
+    re: /\.date_2=0x[0-9a-f]+:<JSDate: 1>/,
+    desc: ".date_2 JSDate element",
   }
+
 };
 
 const contextTests = {


### PR DESCRIPTION
Move logic that was representing a JSDate object
to a string from the Printer::Stringfy method to
the JSDate class, implementing "ToString" method.