### PR TITLE
src: make source list -l flag optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,11 @@ The following subcommands are supported:
       print           -- Print short description of the JavaScript value.
 
                          Syntax: v8 print expr
-      source          -- Source code information
+      source list     -- Print source lines around the currently selected 
+                         JavaScript frame.
+                         Syntax: v8 source list [flags]
+                         Flags:
+                         * -l <line> - Print source code below line <line>.
 
 For more help on any particular subcommand, type 'help <command> <subcommand>'.
 ```

--- a/test/plugin/frame-test.js
+++ b/test/plugin/frame-test.js
@@ -4,6 +4,62 @@ const tape = require('tape');
 
 const common = require('../common');
 
+const sourceCode = [
+"10 function eyecatcher() {",
+"11   crasher();    // # args < # formal parameters inserts an adaptor frame.",
+"12   return this;  // Force definition of |this|.",
+"13 }",
+];
+const lastLine = new RegExp(sourceCode[sourceCode.length - 1]);
+
+function fatalError(t, sess, err) {
+  t.error(err);
+  sess.quit();
+  return t.end();
+}
+
+function testFrameList(t, sess, frameNumber) {
+  sess.send(`frame select ${frameNumber}`);
+  sess.linesUntil(/frame/, (err, lines) => {
+    if (err) {
+      return fatalError(t, sess, err);
+    }
+    sess.send('v8 source list');
+
+    sess.linesUntil(/v8 source list/, (err, lines) => {
+      sess.linesUntil(lastLine, (err, lines) => {
+        if (err) {
+          return fatalError(t, sess, err);
+        }
+        t.equal(lines.length, sourceCode.length,
+                `v8 source list correct size`);
+        for (let i = 0; i < lines.length; i++) {
+          t.equal(lines[i].trim(), sourceCode[i], `v8 source list #${i}`);
+        }
+
+        sess.send('v8 source list -l 2');
+
+        sess.linesUntil(/v8 source list/, (err, lines) => {
+          sess.linesUntil(lastLine, (err, lines) => {
+            if (err) {
+              return fatalError(t, sess, err);
+            }
+            t.equal(lines.length, sourceCode.length - 1,
+                    `v8 source list -l 2 correct size`);
+            for (let i = 0; i < lines.length; i++) {
+              t.equal(lines[i].trim(), sourceCode[i + 1],
+                      `v8 source list -l 2 #${i}`);
+            }
+
+            sess.quit();
+            t.end();
+          });
+        });
+      });
+    });
+  });
+}
+
 tape('v8 stack', (t) => {
   t.timeoutAfter(15000);
 
@@ -43,7 +99,13 @@ tape('v8 stack', (t) => {
     // The test adds unreachable `return this` statements as a workaround.
     t.ok(/this=(0x[0-9a-f]+):<Global proxy>/.test(eyecatcher), 'global this');
     t.ok(/this=(0x[0-9a-f]+):<undefined>/.test(crasher), 'undefined this');
-    sess.quit();
-    t.end();
+
+    const eyecatcherFrame = eyecatcher.match(/frame #([0-9]+)/)[1];
+    if (!eyecatcherFrame) {
+      fatalError(t, sess, "Couldn't determine eyecather's frame number");
+    }
+
+    testFrameList(t, sess, eyecatcherFrame);
+
   });
 });

--- a/test/plugin/usage-test.js
+++ b/test/plugin/usage-test.js
@@ -20,13 +20,6 @@ tape('usage messages', (t) => {
     t.error(err);
     const re = /^error: USAGE: v8 print expr$/;
     t.ok(containsLine(lines, re), 'print usage message');
-    sess.send('v8 source list');
-  });
-
-  sess.stderr.linesUntil(/USAGE/, (err, lines) => {
-    t.error(err);
-    const re = /^error: USAGE: v8 source list$/;
-    t.ok(containsLine(lines, re), 'list usage message');
     sess.send('v8 findjsinstances');
   });
 


### PR DESCRIPTION
`v8 source list` was expecting an undocumented flag -l, which is the
first line the command will output from source code. This commit makes
that flag optional, documents the flag, improves the help message for
this command and adds tests for it.

Fixes: https://github.com/nodejs/llnode/issues/138