### PR TITLE
doc: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The following subcommands are supported:
       getactivehandles  -- Print all pending handles in the queue. Equivalent to running process._getActiveHandles() on
                            the living process.
 
-      getactiverequests -- Print all pending handles in the queue. Equivalent to running process._getActiveHandles() on
+      getactiverequests -- Print all pending requests in the queue. Equivalent to running process._getActiveRequests() on
                            the living process.
 
       inspect         -- Print detailed description and contents of the JavaScript value.


### PR DESCRIPTION
fix commands getactiverequests description typo