### PR TITLE
src: inspcet arguments from an Error object stack

### DIFF
--- a/src/llv8.h
+++ b/src/llv8.h
@@ -290,9 +290,14 @@ class JSError : public JSObject {
   inline std::string stack_trace_property();
 };
 
+class FixedArray;
 class StackFrame {
  public:
+  Value GetReceiver(Error& err);
   JSFunction GetFunction(Error& err);
+  FixedArray GetParameters(Error& err);
+
+  bool HasParameters(Error& err);
 
  private:
   friend StackTrace;
@@ -346,6 +351,7 @@ class StackTrace {
   JSArray frame_array_;
   int multiplier_ = -1;
   int len_ = -1;
+  int has_parameters_ = false;
 };
 
 


### PR DESCRIPTION
This is useful when the process aborts later than a thrown error (for
example, when there's an async rethrow or an unhandled Promise
rejection). V8 changes to make this possible landed in
https://github.com/v8/v8/commit/3724a125.