### PR TITLE
src: add rudimentary Promise support

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -518,6 +518,13 @@ void Types::Load() {
   kLastContextType = LoadConstant("LastContextType");
 
   kJSErrorType = LoadConstant("type_JSError__JS_ERROR_TYPE");
+  kJSPromiseType = LoadConstant("type_JSPromise__JS_PROMISE_TYPE");
+  if (kJSPromiseType == -1) {
+    // NOTE(mmarchini): On Node.js v10.x, JS_PROMISE always comes after
+    // JS_MESSAGE_OBJECT_TYPE in the InstanceType enum.
+    kJSPromiseType =
+        LoadConstant("type_JSMessageObject__JS_MESSAGE_OBJECT_TYPE") + 1;
+  }
   kHeapNumberType = LoadConstant("type_HeapNumber__HEAP_NUMBER_TYPE");
   kMapType = LoadConstant("type_Map__MAP_TYPE");
   kGlobalObjectType =

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -507,6 +507,7 @@ class Types : public Module {
   int64_t kLastContextType;
 
   int64_t kJSErrorType;
+  int64_t kJSPromiseType;
   int64_t kHeapNumberType;
   int64_t kMapType;
   int64_t kGlobalObjectType;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -314,6 +314,7 @@ inline bool JSObject::IsObjectType(LLV8* v8, int64_t type) {
   return type == v8->types()->kJSObjectType ||
          type == v8->types()->kJSAPIObjectType ||
          type == v8->types()->kJSErrorType ||
+         type == v8->types()->kJSPromiseType ||
          type == v8->types()->kJSSpecialAPIObjectType;
 }
 

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -67,6 +67,8 @@ function closure() {
   c.hashmap['stringifiedError'] = new Error('test');
   c.hashmap['stringifiedErrorStack'] = c.hashmap['stringifiedError'].stack;
 
+  c.hashmap['promise'] = new Promise(() => {});
+
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;
   c.hashmap[23] = /regexp/;

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -187,6 +187,10 @@ const hashMapTests = {
       });
     }
   },
+  'promise': {
+    re: /.promise=(0x[0-9a-f]+):<Object: Promise>/,
+    desc: '.promise Promise property'
+  },
   // .array=0x000003df9cbe7919:<Array: length=6>,
   'array': {
     re: /.array=(0x[0-9a-f]+):<Array: length=6>/,


### PR DESCRIPTION
This patch allows llnode to list Promise objects with findjsobjects,
findjsinstances and findrefs. We can investigate more fancy Promise
features in the future (such as listing handlers, Promise status, etc.).