### PR TITLE
doc: add collaborator guide

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -6,4 +6,5 @@ with the following exception:
 
 llnode Collaborators are allowed to approve their own Pull Requests if it has
 been opened for at least 7 days and there was no reviews from other
-collaborators.
+collaborators. All other landing criteria still have to be met even if its
+self-approved.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -1,0 +1,9 @@
+# llnode Collaborator Guide
+
+llnode follows 
+[Node.js Collaborator Guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md), 
+with the following exception:
+
+llnode Collaborators are allowed to approve their own Pull Requests if it has
+been opened for at least 7 days and there was no reviews from other
+collaborators.


### PR DESCRIPTION
llnode has been unofficially following the Node.js Collaborator Guide
wrt Approving and Landing PRs policy. On the downside, these policies
were written for a large project with 100+ collaborators and dozens of
active collaborators daily. llnode has only a few collaborators, and
some policies slow the project quite a bit.

This commit adds COLLABORATOR_GUIDE.md with a link to Node.js
Collaborator Guide, so we'll start to follow these guidelines
officially. It also adds one exception to ensure the project can move
forward with a limited number of collaborators.

Fixes: https://github.com/nodejs/llnode/issues/242