### PR TITLE
doc: add collaborator guide

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -1,0 +1,4 @@
+# llnode Collaborator Guide
+
+llnode follows the
+[Node.js Collaborator Guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md).


### PR DESCRIPTION
llnode has been unofficially following the Node.js Collaborator Guide
wrt Approving and Landing PRs policy. This commit adds
COLLABORATOR_GUIDE.md with a link to Node.js Collaborator Guide, so
we'll start to follow these guidelines officially.

Fixes: https://github.com/nodejs/llnode/issues/242