### PR TITLE
src: apply clang-format rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "codecov-upload-js": "codecov --disable=gcov --file=coverage-js.lcov",
     "codecov-upload": "npm run codecov-upload-cc && npm run codecov-upload-js",
     "linter": "node scripts/linter.js",
-    "format": "clang-format -i src/*"
+    "format": "npx clang-format -i src/*"
   },
   "repository": {
     "type": "git",

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -635,13 +635,8 @@ void FindReferencesCmd::ScanForReferences(ObjectScanner* scanner) {
 }
 
 void FindReferencesCmd::PrintRecursiveReferences(
-  lldb::SBCommandReturnObject& result,
-  ScanOptions* options,
-  ReferencesVector* visited_references,
-  uint64_t address,
-  int level
-)
-{
+    lldb::SBCommandReturnObject& result, ScanOptions* options,
+    ReferencesVector* visited_references, uint64_t address, int level) {
   Settings* settings = Settings::GetSettings();
   unsigned int padding = settings->GetTreePadding();
 
@@ -649,24 +644,19 @@ void FindReferencesCmd::PrintRecursiveReferences(
 
   result.Printf("%s", branch.c_str());
 
-  if (find(visited_references->begin(), visited_references->end(), address) != visited_references->end())
-  {
+  if (find(visited_references->begin(), visited_references->end(), address) !=
+      visited_references->end()) {
     std::stringstream seen_str;
-    seen_str << rang::fg::red << " [seen above]" << rang::fg::reset << std::endl;
+    seen_str << rang::fg::red << " [seen above]" << rang::fg::reset
+             << std::endl;
     result.Printf(seen_str.str().c_str());
   } else {
     visited_references->push_back(address);
     v8::Value value(llscan_->v8(), address);
     ReferenceScanner scanner_(llscan_, value);
     ReferencesVector* references_ = scanner_.GetReferences();
-    PrintReferences(
-      result,
-      references_,
-      &scanner_,
-      options,
-      visited_references,
-      level + 1
-    );
+    PrintReferences(result, references_, &scanner_, options, visited_references,
+                    level + 1);
   }
 }
 
@@ -696,7 +686,8 @@ void FindReferencesCmd::PrintReferences(
       scanner->PrintRefs(result, js_obj, err, level);
 
       if (options->recursive_scan) {
-        PrintRecursiveReferences(result, options, already_visited_references, addr, level);
+        PrintRecursiveReferences(result, options, already_visited_references,
+                                 addr, level);
       }
 
     } else if (type < v8->types()->kFirstNonstringType) {
@@ -704,7 +695,8 @@ void FindReferencesCmd::PrintReferences(
       scanner->PrintRefs(result, str, err, level);
 
       if (options->recursive_scan) {
-        PrintRecursiveReferences(result, options, already_visited_references, addr, level);
+        PrintRecursiveReferences(result, options, already_visited_references,
+                                 addr, level);
       }
 
     } else if (type == v8->types()->kJSTypedArrayType) {
@@ -820,7 +812,8 @@ void FindReferencesCmd::ReferenceScanner::PrintContextRefs(
                       search_value_.raw());
 
         if (options->recursive_scan) {
-          cli_cmd_->PrintRecursiveReferences(result, options, already_visited_references, c.raw(), level);
+          cli_cmd_->PrintRecursiveReferences(
+              result, options, already_visited_references, c.raw(), level);
         }
       }
     }

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -132,13 +132,10 @@ class FindReferencesCmd : public CommandBase {
 
   void ScanForReferences(ObjectScanner* scanner);
 
-  void PrintRecursiveReferences(
-    lldb::SBCommandReturnObject& result,
-    ScanOptions* options,
-    ReferencesVector* visited_references,
-    uint64_t address,
-    int level
-  );
+  void PrintRecursiveReferences(lldb::SBCommandReturnObject& result,
+                                ScanOptions* options,
+                                ReferencesVector* visited_references,
+                                uint64_t address, int level);
 
   class ReferenceScanner : public ObjectScanner {
    public:

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -1,6 +1,6 @@
 #include <cinttypes>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 #include "deps/rang/include/rang.hpp"
 #include "src/llv8-inl.h"


### PR DESCRIPTION
Since GitHub/Travis won't rerun tests for Pull Requests when `master` is updated, some commits landed after https://github.com/nodejs/llnode/commit/85f067aad8737d0d8891fd42b41694415f951a24, which made our linter test fail on `master. Also, since there are only a few open pull requests now, this is unlikely to happen again.