### PR TITLE
src: reduce redundant "error:" for `inspect` and `findrefs`

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -192,10 +192,8 @@ bool PrintCmd::DoExecute(SBDebugger d, char** cmd,
   SBExpressionOptions options;
   SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
   if (value.GetError().Fail()) {
-    SBStream desc;
-    if (value.GetError().GetDescription(desc)) {
-      result.SetError(desc.GetData());
-    }
+    SBError error = value.GetError();
+    result.SetError(error);
     result.SetStatus(eReturnStatusFailed);
     return false;
   }

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -504,10 +504,8 @@ bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
       SBExpressionOptions options;
       SBValue value = target.EvaluateExpression(full_cmd.c_str(), options);
       if (value.GetError().Fail()) {
-        SBStream desc;
-        if (value.GetError().GetDescription(desc)) {
-          result.SetError(desc.GetData());
-        }
+        SBError error = value.GetError();
+        result.SetError(error);
         result.SetStatus(eReturnStatusFailed);
         return false;
       }

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -546,7 +546,7 @@ function verifyHashMap(t, sess) {
     const parent = 'hashmap';
     const addresses = collectMembers(
         t, lines.join('\n'), hashMapTests, parent);
-    verifyMembers(t, sess, addresses, hashMapTests, parent, teardown);
+    verifyMembers(t, sess, addresses, hashMapTests, parent, verifyInvalidExpr);
   });
 }
 
@@ -612,6 +612,20 @@ function verifyMembers(t, sess, addresses, tests, parent, next) {
 
   // Kickoff
   verifyProperty(t, sess, addresses, 0);
+}
+
+function verifyInvalidExpr(t, sess) {
+  sess.send('v8 inspect invalid_expr');
+  sess.waitError(/error:/, (err, line) => {
+    if (err) {
+      return teardown(t, sess, err);
+    }
+    t.ok(
+      /error: error: use of undeclared identifier 'invalid_expr'/.test(line),
+      'invalid expression should return an error'
+    );
+    teardown(t, sess);
+  });
 }
 
 tape('v8 inspect', (t) => {


### PR DESCRIPTION
When `inspect` or `findrefs` an invalid expr, llnode will print
an error message prefixed with "error: error: error:". This PR
will reduce one redundant "error:" for such scenario and it
seems that we can't remove the other redundant "error:" by
calling SB API only.

Before this PR:

```
(llnode) v8 inspect invalid_addr
error: error: error: use of undeclared identifier 'invalid_addr'
(llnode) v8 findrefs -v invalid_addr
error: error: error: use of undeclared identifier 'invalid_addr'
```

After:

```
(llnode) v8 inspect invalid_addr
error: error: use of undeclared identifier 'invalid_addr'
(llnode) v8 findrefs -v invalid_addr
error: error: use of undeclared identifier 'invalid_addr'
```

The other redundant "error:" seems to come from [here](https://github.com/llvm-mirror/lldb/blob/master/source/API/SBValue.cpp#L274) and I couldn't find a way to remove it by calling SB API only.
