### PR TITLE
src: fix JSError inspection with stringified stack

### DIFF
--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -1271,6 +1271,13 @@ StackTrace::Iterator StackTrace::end() {
 
 StackTrace::StackTrace(JSArray frame_array, Error& err)
     : frame_array_(frame_array) {
+  if (!frame_array.Check()) {
+    PRINT_DEBUG("JS Array is not a valid object");
+    len_ = -1;
+    multiplier_ = -1;
+    return;
+  }
+
   v8::Value maybe_stack_len = frame_array.GetArrayElement(0, err);
 
   if (err.Fail()) {

--- a/test/fixtures/inspect-scenario.js
+++ b/test/fixtures/inspect-scenario.js
@@ -64,6 +64,9 @@ function closure() {
   c.hashmap['error'].code = 'ERR_TEST';
   c.hashmap['error'].errno = 1;
 
+  c.hashmap['stringifiedError'] = new Error('test');
+  c.hashmap['stringifiedErrorStack'] = c.hashmap['stringifiedError'].stack;
+
   c.hashmap[0] = null;
   c.hashmap[4] = undefined;
   c.hashmap[23] = /regexp/;

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -161,6 +161,28 @@ const hashMapTests = {
       });
     }
   },
+  // .stringifiedError=0x0000392d5d661119:<Object: Error>
+  'error': {
+    re: /.stringifiedError=(0x[0-9a-f]+):<Object: Error>/,
+    desc: '.stringifiedError Error property with stringified stack',
+    validator(t, sess, addresses, name, cb) {
+      const address = addresses[name];
+      sess.send(`v8 inspect ${address}`);
+
+      sess.linesUntil(/}>/, (err, lines) => {
+        if (err) return cb(err);
+        lines = lines.join('\n');
+
+        let strStackMatch = lines.match(/stack=(0x[0-9a-f]+):<String: /i);
+        t.ok(strStackMatch, 'hashmap.stringifiedError should have stringified stack');
+
+        let stackMatch  = lines.match(/error stack {/i);
+        t.notOk(stackMatch, 'Error object with stringified stack should not have an error stack');
+
+        cb(null);
+      });
+    }
+  },
   // .array=0x000003df9cbe7919:<Array: length=6>,
   'array': {
     re: /.array=(0x[0-9a-f]+):<Array: length=6>/,


### PR DESCRIPTION
When the `stack` property of an Error object is accessed in V8, a
stringified version of the stack is generated, and then the "raw stack"
(with FP and arguments) is removed from memory. Our current inspection
code couldn't handle this because it was not checking if the raw stack
was a valid object. This commit makes that code more robust and thus
fixes inspection of error objects with stringified stacks.