### PR TITLE
build: drop v6.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,6 @@ matrix:
     # Ubuntu Trusty #
     #################
 
-    - name: "[Trusty] Node.js v6.x"
-      sudo: required
-      dist: trusty
-      before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install lldb-3.9 liblldb-3.9-dev lcov -y
-      install:
-        - npm install --llnode_build_addon=true --llnode_coverage=true
-      script: TEST_LLDB_BINARY=`which lldb-3.9` npm run nyc-test-all
-      node_js: "6"
-      after_success:
-        - npm run coverage
-        - npm run codecov-upload
-
     - name: "[Trusty] Node.js v8.x"
       sudo: required
       dist: trusty
@@ -104,13 +90,6 @@ matrix:
     ########
     # OS X #
     ########
-
-    - name: "[OSX] Node.js v6.x"
-      os: osx
-      osx_image: xcode9.3
-      install: npm install --llnode_build_addon=true
-      script: npm run test-all
-      node_js: "6"
 
     - name: "[OSX] Node.js v8.x"
       os: osx

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ https://asciinema.org/a/29589
 
 ## Build Status
 
-| Version | v6.x                    | v8.x                    | v10.x                     | v11.x                     | master                        | v8-canary                        |
-|---------|-------------------------|-------------------------|---------------------------|---------------------------|-------------------------------|----------------------------------|
-| **Trusty**  | [![v6.x badge][v6-trusty-badge]][travis] | [![v8.x badge][v8-trusty-badge]][travis] | [![v10.x badge][v10-trusty-badge]][travis] | [![v11.x badge][v11-trusty-badge]][travis] | [![master badge][master-trusty-badge]][travis] | [![v8-canary badge][canary-trusty-badge]][travis] |
-| **OS X**  | [![v6.x badge][v6-osx-badge]][travis] | [![v8.x badge][v8-osx-badge]][travis] | [![v10.x badge][v10-osx-badge]][travis] | [![v11.x badge][v11-osx-badge]][travis] | - | - |
+| Version | v8.x                    | v10.x                     | v11.x                     | master                        | v8-canary                        |
+|---------|-------------------------|---------------------------|---------------------------|-------------------------------|----------------------------------|
+| **Trusty**  | [![v8.x badge][v8-trusty-badge]][travis] | [![v10.x badge][v10-trusty-badge]][travis] | [![v11.x badge][v11-trusty-badge]][travis] | [![master badge][master-trusty-badge]][travis] | [![v8-canary badge][canary-trusty-badge]][travis] |
+| **OS X**  | [![v8.x badge][v8-osx-badge]][travis] | [![v10.x badge][v10-osx-badge]][travis] | [![v11.x badge][v11-osx-badge]][travis] | - | - |
 
 We have nightly test runs against all Node.js active release lines. We also test
 against Node.js master and Node.js v8-canary nightly builds to help us identify
@@ -385,15 +385,13 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [travis]: https://travis-ci.com/nodejs/llnode
-[v6-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/1?use_travis_com=true
-[v8-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/2?use_travis_com=true
-[v10-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/3?use_travis_com=true
-[v11-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/4?use_travis_com=true
+[v8-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/1?use_travis_com=true
+[v10-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/2?use_travis_com=true
+[v11-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/3?use_travis_com=true
 
-[v6-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/5?use_travis_com=true
-[v8-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/6?use_travis_com=true
-[v10-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/7?use_travis_com=true
-[v11-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/8?use_travis_com=true
+[v8-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/4?use_travis_com=true
+[v10-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/5?use_travis_com=true
+[v11-osx-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/6?use_travis_com=true
 
-[master-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/10?use_travis_com=true
-[canary-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/11?use_travis_com=true
+[master-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/8?use_travis_com=true
+[canary-trusty-badge]: https://travisci-matrix-badges.herokuapp.com/repos/nodejs/llnode/branches/master/9?use_travis_com=true


### PR DESCRIPTION
Node.js v6.x is EOL. Keeping it around makes it more dificult to support
new versions, so dropping support seems reasonable. This is
semver-major.