### PR TITLE
src: improve Check() reliability

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -892,11 +892,12 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
     SBCommandReturnObject& result, v8::String& str, Error& err, int level) {
   v8::LLV8* v8 = str.v8();
 
-  int64_t repr = str.Representation(err);
+  v8::CheckedType<int64_t> repr = str.Representation(err);
+  RETURN_IF_INVALID(repr, );
 
   // Concatenated and sliced strings refer to other strings so
   // we need to check their references.
-  if (repr == v8->string()->kSlicedStringTag) {
+  if (*repr == v8->string()->kSlicedStringTag) {
     v8::SlicedString sliced_str(str);
     v8::String parent = sliced_str.Parent(err);
     if (err.Success() && parent.raw() == search_value_.raw()) {
@@ -906,7 +907,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
       result.Printf(reference_template.c_str(), str.raw(), type_name.c_str(),
                     "<Parent>", search_value_.raw());
     }
-  } else if (repr == v8->string()->kConsStringTag) {
+  } else if (*repr == v8->string()->kConsStringTag) {
     v8::ConsString cons_str(str);
 
     v8::String first = cons_str.First(err);
@@ -926,7 +927,7 @@ void FindReferencesCmd::ReferenceScanner::PrintRefs(
       result.Printf(reference_template.c_str(), str.raw(), type_name.c_str(),
                     "<Second>", search_value_.raw());
     }
-  } else if (repr == v8->string()->kThinStringTag) {
+  } else if (*repr == v8->string()->kThinStringTag) {
     v8::ThinString thin_str(str);
     v8::String actual = thin_str.Actual(err);
     if (err.Success() && actual.raw() == search_value_.raw()) {
@@ -985,12 +986,13 @@ void FindReferencesCmd::ReferenceScanner::ScanRefs(v8::String& str,
 
   v8::LLV8* v8 = str.v8();
 
-  int64_t repr = str.Representation(err);
+  v8::CheckedType<int64_t> repr = str.Representation(err);
+  RETURN_IF_INVALID(repr, );
 
   // Concatenated and sliced strings refer to other strings so
   // we need to check their references.
 
-  if (repr == v8->string()->kSlicedStringTag) {
+  if (*repr == v8->string()->kSlicedStringTag) {
     v8::SlicedString sliced_str(str);
     v8::String parent = sliced_str.Parent(err);
 
@@ -999,7 +1001,7 @@ void FindReferencesCmd::ReferenceScanner::ScanRefs(v8::String& str,
       references->push_back(str.raw());
     }
 
-  } else if (repr == v8->string()->kConsStringTag) {
+  } else if (*repr == v8->string()->kConsStringTag) {
     v8::ConsString cons_str(str);
 
     v8::String first = cons_str.First(err);
@@ -1013,7 +1015,7 @@ void FindReferencesCmd::ReferenceScanner::ScanRefs(v8::String& str,
       references = llscan_->GetReferencesByValue(second.raw());
       references->push_back(str.raw());
     }
-  } else if (repr == v8->string()->kThinStringTag) {
+  } else if (*repr == v8->string()->kThinStringTag) {
     v8::ThinString thin_str(str);
     v8::String actual = thin_str.Actual(err);
 
@@ -1183,10 +1185,10 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
   // Concatenated and sliced strings refer to other strings so
   // we need to check their references.
 
-  int64_t repr = str.Representation(err);
-  if (err.Fail()) return;
+  v8::CheckedType<int64_t> repr = str.Representation(err);
+  RETURN_IF_INVALID(repr, );
 
-  if (repr == v8->string()->kSlicedStringTag) {
+  if (*repr == v8->string()->kSlicedStringTag) {
     v8::SlicedString sliced_str(str);
     v8::String parent_str = sliced_str.Parent(err);
     if (err.Fail()) return;
@@ -1197,7 +1199,7 @@ void FindReferencesCmd::StringScanner::PrintRefs(SBCommandReturnObject& result,
                     type_name.c_str(), "<Parent>", parent_str.raw(),
                     parent.c_str());
     }
-  } else if (repr == v8->string()->kConsStringTag) {
+  } else if (*repr == v8->string()->kConsStringTag) {
     v8::ConsString cons_str(str);
 
     v8::String first_str = cons_str.First(err);
@@ -1313,10 +1315,10 @@ void FindReferencesCmd::StringScanner::ScanRefs(v8::String& str, Error& err) {
   // Concatenated and sliced strings refer to other strings so
   // we need to check their references.
 
-  int64_t repr = str.Representation(err);
-  if (err.Fail()) return;
+  v8::CheckedType<int64_t> repr = str.Representation(err);
+  RETURN_IF_INVALID(repr, );
 
-  if (repr == v8->string()->kSlicedStringTag) {
+  if (*repr == v8->string()->kSlicedStringTag) {
     v8::SlicedString sliced_str(str);
     v8::String parent_str = sliced_str.Parent(err);
     if (err.Fail()) return;
@@ -1325,7 +1327,7 @@ void FindReferencesCmd::StringScanner::ScanRefs(v8::String& str, Error& err) {
       references = llscan_->GetReferencesByString(parent);
       references->push_back(str.raw());
     }
-  } else if (repr == v8->string()->kConsStringTag) {
+  } else if (*repr == v8->string()->kConsStringTag) {
     v8::ConsString cons_str(str);
 
     v8::String first_str = cons_str.First(err);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -720,13 +720,13 @@ std::string Symbol::ToString(Error& err) {
 
 
 std::string String::ToString(Error& err) {
-  int64_t repr = Representation(err);
-  if (err.Fail()) return std::string();
+  CheckedType<int64_t> repr = Representation(err);
+  RETURN_IF_INVALID(repr, std::string());
 
   int64_t encoding = Encoding(err);
   if (err.Fail()) return std::string();
 
-  if (repr == v8()->string()->kSeqStringTag) {
+  if (*repr == v8()->string()->kSeqStringTag) {
     if (encoding == v8()->string()->kOneByteStringTag) {
       OneByteString one(this);
       return one.ToString(err);
@@ -739,27 +739,27 @@ std::string String::ToString(Error& err) {
     return std::string();
   }
 
-  if (repr == v8()->string()->kConsStringTag) {
+  if (*repr == v8()->string()->kConsStringTag) {
     ConsString cons(this);
     return cons.ToString(err);
   }
 
-  if (repr == v8()->string()->kSlicedStringTag) {
+  if (*repr == v8()->string()->kSlicedStringTag) {
     SlicedString sliced(this);
     return sliced.ToString(err);
   }
 
   // TODO(indutny): add support for external strings
-  if (repr == v8()->string()->kExternalStringTag) {
+  if (*repr == v8()->string()->kExternalStringTag) {
     return std::string("(external)");
   }
 
-  if (repr == v8()->string()->kThinStringTag) {
+  if (*repr == v8()->string()->kThinStringTag) {
     ThinString thin(this);
     return thin.ToString(err);
   }
 
-  err = Error::Failure("Unsupported string representation %" PRId64, repr);
+  err = Error::Failure("Unsupported string representation %" PRId64, *repr);
   return std::string();
 }
 


### PR DESCRIPTION
This is a first step towards making llnode more reliable. Right now,
llnode doesn't allow us to deal with partially-loaded objects (some
fields working, some not working). As a postmortem tool, llnode should
be able to handle partial loading of objects, as this is the proper way
to deal with corrupt memory. If llnode can handle corrupted memory, it
will also be able to understand the memory of unsupported Node.js
versons, although some fields and objects won't load.

There are two problems regarding reliability in llnode: first, we have
several attempts to access fields from the crashed/paused process memory
without validating if we have enough information (and correct
informaton) to do so. Second, we use Error::Fail() as the primary tool
to verify if there was an error loading a field/objects/etc., but
Error::Fail usually propagates and will cause us to prematurely stop
processing the memory.

This commit introduces a few things to help us improve reliability in
the future:

  - Value classes now have a `valid_` member, and Check() will take this
    member into account.
  - A new class, CheckedType, will let us wrap primitive C++ types which
    were loaded from the paused/crashed process memory, so we can have a
    Check() method for those values as well to verify if it was possible
    to load the value successfuly.
  - Two new macros, RETURN_IF_INVALID and RETURN_IF_THIS_INVALID, to
    make it easier to return from a function (with a default value) when
    a object/value was not loaded properly.

The goals in the future are:

  - Replace all uses of Error::Fail as a loading validation tool with
    RETURN_IF_INVALID, keeping Error::Fail only for unrecoverable errors
    (instead of the double semantic it has today).
  - Ensure all methods in llv8.h return either a Value subclass, or a
    primitive type wrapped in CheckedType
  - Ensure all calls to methods which will load from the target process
    memory are followed by RETURN_IF_INVALID.
  - Ensure all methods in llv8.h start with RETURN_IF_THIS_INVALID.

We could make all those changes in a single PR, but it would take a huge
amount of work and the PR would be extremely long, making it harder to
review. Instead, I suggest we make incremental changes as we see fit,
until we achieve the goals described above.

The method of choice to start was String::Representation, because by
making this method more robust we fix a crash on Node.js v12 after
running `v8 bt` if there's an optimized function on the stack (the
function won't be translated, but it's better than a hard crash).