### PR TITLE
doc: update collaborator guide to match the project size

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -1,4 +1,11 @@
 # llnode Collaborator Guide
 
 llnode follows the
-[Node.js Collaborator Guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md).
+[Node.js Collaborator Guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md),
+with the following differences:
+
+  - At least one Collaborator must approve a pull request before the pull 
+    request lands.
+  - There's no minimum wait time for landing a pull request. Pull requests can
+    land as soon as they get approved by at least one Collaborator.
+  - Approval must be from Collaborators who are not authors of the change.


### PR DESCRIPTION
This commits modifies our collaborator guide to match the current
project size. llnode is way smaller than nodejs/node, and requiring two
approvals to land a change/one approval with a seven day wait can be
quite bureaucratic. Two approvals represent 50% of our active reviewers
at the moment, which is quite a lot. Changing the requirements to one
approval with no wait time once a PR gets approved makes more sense for
this project, and it also matches other smaller projects across the
organization.