### PR TITLE
src: fix gcc/clang warnings

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -477,8 +477,7 @@ bool PluginInitialize(SBDebugger d) {
 
   setPropertyCmd.AddCommand("color", new llnode::SetPropertyColorCmd(),
                             "Set color property value");
-  setPropertyCmd.AddCommand("tree-padding",
-                            new llnode::SetTreePaddingCmd(&llv8),
+  setPropertyCmd.AddCommand("tree-padding", new llnode::SetTreePaddingCmd(),
                             "Set tree-padding value");
 
   interpreter.AddCommand("findjsobjects", new llnode::FindObjectsCmd(&llscan),

--- a/src/llnode.h
+++ b/src/llnode.h
@@ -32,14 +32,10 @@ class SetPropertyColorCmd : public CommandBase {
 
 class SetTreePaddingCmd : public CommandBase {
  public:
-  SetTreePaddingCmd(v8::LLV8* llv8) : llv8_(llv8) {}
   ~SetTreePaddingCmd() override {}
 
   bool DoExecute(lldb::SBDebugger d, char** cmd,
                  lldb::SBCommandReturnObject& result) override;
-
- private:
-  v8::LLV8* llv8_;
 };
 
 class PrintCmd : public CommandBase {

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -647,7 +647,7 @@ void FindReferencesCmd::PrintRecursiveReferences(
     std::stringstream seen_str;
     seen_str << rang::fg::red << " [seen above]" << rang::fg::reset
              << std::endl;
-    result.Printf(seen_str.str().c_str());
+    result.Printf("%s", seen_str.str().c_str());
   } else {
     visited_references->push_back(address);
     v8::Value value(llscan_->v8(), address);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -111,7 +111,11 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
   }
 
   err = Error::Ok();
-  return *reinterpret_cast<double*>(&value);
+  // dereferencing type-punned pointer will break strict-aliasing rules
+  // return *reinterpret_cast<double*>(&value);
+  double dvalue;
+  std::memcpy(&dvalue, &value, sizeof(double));
+  return dvalue;
 }
 
 
@@ -1288,8 +1292,8 @@ StackTrace::StackTrace(JSArray frame_array, Error& err)
     if ((len_ != 0) ||
         ((frame_array_.GetArrayLength(err) - 1) % multiplier_ != 0)) {
       Error::PrintInDebugMode(
-          "JSArray doesn't look like a Stack Frames array. stack_len: %lld "
-          "array_len: %lld",
+          "JSArray doesn't look like a Stack Frames array. stack_len: %d "
+          "array_len: %ld",
           len_, frame_array_.GetArrayLength(err));
       len_ = -1;
       multiplier_ = -1;


### PR DESCRIPTION
2 warnings still here. `maybe-uninitialized` looks like GCC bug. `unused-but-set-variable` introduced in https://github.com/nodejs/llnode/commit/b53010b97c6fec725439b0b0da3560b0f23fb9fc#diff-86a9160147028a03800f8ba4fa555285R1502-R1525 -- not sure how should be handled.

PR GCC (9.2.1):
```
../src/llv8.cc: In member function ‘llnode::v8::Value llnode::v8::JSObject::GetDescriptorProperty(std::string, llnode::v8::Map, llnode::Error&)’:
../src/llv8.cc:1149:14: warning: variable ‘value’ set but not used [-Wunused-but-set-variable]
 1149 |       double value;
      |              ^~~~~
  CXX(target) Release/obj.target/plugin/src/llv8-constants.o
  CXX(target) Release/obj.target/plugin/src/llscan.o
../src/llscan.cc: In member function ‘virtual bool llnode::FindReferencesCmd::DoExecute(lldb::SBDebugger, char**, lldb::SBCommandReturnObject&)’:
../src/llscan.cc:568:22: warning: ‘scanner’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  568 |     ScanForReferences(scanner);
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~
```

master GCC (9.2.1):
```
../src/llv8.cc: In member function ‘double llnode::v8::LLV8::LoadDouble(int64_t, llnode::Error&)’:
../src/llv8.cc:114:11: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  114 |   return *reinterpret_cast<double*>(&value);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/llv8.cc: In member function ‘llnode::v8::Value llnode::v8::JSObject::GetDescriptorProperty(std::string, llnode::v8::Map, llnode::Error&)’:
../src/llv8.cc:1149:14: warning: variable ‘value’ set but not used [-Wunused-but-set-variable]
 1149 |       double value;
      |              ^~~~~
../src/llv8.cc: In constructor ‘llnode::v8::StackTrace::StackTrace(llnode::v8::JSArray, llnode::Error&)’:
../src/llv8.cc:1291:74: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 2 has type ‘int’ [-Wformat=]
 1291 |           "JSArray doesn't look like a Stack Frames array. stack_len: %lld "
      |                                                                       ~~~^
      |                                                                          |
      |                                                                          long long int
      |                                                                       %d
 1292 |           "array_len: %lld",
 1293 |           len_, frame_array_.GetArrayLength(err));
      |           ~~~~                                                            
      |           |
      |           int
../src/llv8.cc:1292:26: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
 1292 |           "array_len: %lld",
      |                       ~~~^
      |                          |
      |                          long long int
      |                       %ld
 1293 |           len_, frame_array_.GetArrayLength(err));
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                            |
      |                                            int64_t {aka long int}
../src/llscan.cc: In member function ‘virtual bool llnode::FindReferencesCmd::DoExecute(lldb::SBDebugger, char**, lldb::SBCommandReturnObject&)’:
../src/llscan.cc:568:22: warning: ‘scanner’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  568 |     ScanForReferences(scanner);
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~
```

master clang (8.0.0):
```
In file included from ../src/llnode.cc:13:
../src/llnode.h:42:13: warning: private field 'llv8_' is not used [-Wunused-private-field]
  v8::LLV8* llv8_;
            ^
1 warning generated.
../src/llv8.cc:1293:11: warning: format specifies type 'long long' but the argument has type 'int' [-Wformat]
          len_, frame_array_.GetArrayLength(err));
          ^~~~
../src/llv8.cc:1293:17: warning: format specifies type 'long long' but the argument has type 'int64_t' (aka 'long') [-Wformat]
          len_, frame_array_.GetArrayLength(err));
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
../src/llscan.cc:650:19: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    result.Printf(seen_str.str().c_str());
                  ^~~~~~~~~~~~~~~~~~~~~~
../src/llscan.cc:650:19: note: treat the string as an argument to avoid this
    result.Printf(seen_str.str().c_str());
                  ^
                  "%s",
1 warning generated.
```