### PR TITLE
src: use new SystemPointerSize constant

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -30,7 +30,7 @@ void Module::Assign(SBTarget target, Common* common) {
 
 
 void Common::Load() {
-  kPointerSize = 1 << LoadConstant("PointerSizeLog2");
+  kPointerSize = 1 << LoadConstant("PointerSizeLog2", "SystemPointerSizeLog2");
   kVersionMajor = LoadRawConstant("v8::internal::Version::major_");
   kVersionMinor = LoadRawConstant("v8::internal::Version::minor_");
   kVersionPatch = LoadRawConstant("v8::internal::Version::patch_");


### PR DESCRIPTION
This alone should fix a lot of issues. It was enough to get a reasonable
stack trace from a Node.js v12.3.0 core dump, ran with
--interpreted-frames-native-stack. For some reason `v8 bt` is not
working when running Node.js in lldb.