### PR TITLE
src: Treat embeded builtins as V8 functions

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -69,7 +69,12 @@ bool BacktraceCmd::DoExecute(SBDebugger d, char** cmd,
     const char star = (frame == selected_frame ? '*' : ' ');
     const uint64_t pc = frame.GetPC();
 
-    if (!frame.GetSymbol().IsValid()) {
+    // TODO(mmarchini): There might be a better way to check for V8 builtins
+    // embeded in the binary.
+    auto c_function_name = frame.GetFunctionName();
+    std::string function_name(c_function_name != nullptr ? c_function_name
+                                                         : "");
+    if (!frame.GetSymbol().IsValid() || function_name.find("Builtins_") == 0) {
       Error err;
       v8::JSFrame v8_frame(llv8_, static_cast<int64_t>(frame.GetFP()));
       Printer printer(llv8_);


### PR DESCRIPTION
On Node.js v12 most builtins are compiled during build time and embeded
in the binary. Because of that, LLDB will think it knows how to handle
these frames (especially JavaScript frames). To correctly handle those
frames, we check the function name, if it starts with `Builtins_` we'll
handle it as a JIT function. This method should be safe since any C++
function coming from V8 or Node.js will be mangled, thus beginning with
`_Z...`. There might be a better way to handle this, but for now this
check should be enough.