### PR TITLE
src: fix String::Length for Node.js v12.3.0

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -299,7 +299,12 @@ void String::Load() {
   kExternalStringTag = LoadConstant("ExternalStringTag");
   kThinStringTag = LoadConstant("ThinStringTag");
 
+  kLengthIsSmi = true;
   kLengthOffset = LoadConstant("class_String__length__SMI");
+  if (kLengthOffset == -1) {
+    kLengthIsSmi = false;
+    kLengthOffset = LoadConstant("class_String__length__int32_t");
+  }
 }
 
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -266,6 +266,7 @@ class String : public Module {
   int64_t kThinStringTag;
 
   int64_t kLengthOffset;
+  bool kLengthIsSmi;
 
  protected:
   void Load();

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -80,6 +80,20 @@ int64_t LLV8::LoadPtr(int64_t addr, Error& err) {
   return value;
 }
 
+template <class T>
+CheckedType<T> LLV8::LoadUnsigned(int64_t addr, uint32_t byte_size) {
+  SBError sberr;
+  int64_t value = process_.ReadUnsignedFromMemory(static_cast<addr_t>(addr),
+                                                  byte_size, sberr);
+
+  if (sberr.Fail()) {
+    PRINT_DEBUG("Failed to load unsigned from v8 memory. Reason: %s",
+                sberr.GetCString());
+    return CheckedType<T>();
+  }
+
+  return CheckedType<T>(value);
+}
 
 int64_t LLV8::LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err) {
   SBError sberr;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -163,7 +163,7 @@ class String : public HeapObject {
 
   inline int64_t Encoding(Error& err);
   inline CheckedType<int64_t> Representation(Error& err);
-  inline Smi Length(Error& err);
+  inline CheckedType<int32_t> Length(Error& err);
 
   std::string ToString(Error& err);
 
@@ -605,8 +605,13 @@ class LLV8 {
   template <class T>
   inline T LoadValue(int64_t addr, Error& err);
 
+  template <class T>
+  inline T LoadValue(int64_t addr);
+
   int64_t LoadConstant(const char* name);
   int64_t LoadPtr(int64_t addr, Error& err);
+  template <class T>
+  CheckedType<T> LoadUnsigned(int64_t addr, uint32_t byte_size);
   int64_t LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err);
   double LoadDouble(int64_t addr, Error& err);
   std::string LoadBytes(int64_t addr, int64_t length, Error& err);


### PR DESCRIPTION
Type of String::Length changed from SMI to int32. This commit changes
String::Length to use the new type. String::Length now returns a
CheckedType, and places calling String::Length will check the type using
.Check instead of Error::Fail, making the code more resilient in case
the String length can't be loaded properly.