### PR TITLE
src: fix function name lookup for inferred names

### DIFF
--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -915,16 +915,25 @@ inline HeapObject ScopeInfo::MaybeFunctionName(Error& err) {
   // metadata to determine in which slot its being stored for the present
   // ScopeInfo, we try to find it heuristically.
   int tries = 3;
+  HeapObject likely_function_name;
   while (tries > 0 && proper_index < Length(err).GetValue()) {
     err = Error();
 
     HeapObject maybe_function_name =
         FixedArray::Get<HeapObject>(proper_index, err);
-    if (err.Success() && String::IsString(v8(), maybe_function_name, err))
-      return maybe_function_name;
+    if (err.Success() && String::IsString(v8(), maybe_function_name, err)) {
+      likely_function_name = maybe_function_name;
+      if (*String(likely_function_name).Length(err) > 0) {
+        return likely_function_name;
+      }
+    }
 
     tries--;
     proper_index++;
+  }
+
+  if (likely_function_name.Check()) {
+    return likely_function_name;
   }
 
   err = Error::Failure("Couldn't get FunctionName from ScopeInfo");

--- a/test/fixtures/frame-scenario.js
+++ b/test/fixtures/frame-scenario.js
@@ -3,13 +3,29 @@ const common = require('../common');
 
 function crasher(unused) {
   'use strict';
-  process.abort();  // Creates an exit frame.
-  return this;      // Force definition of |this|.
+  this.foo = arguments;  // Force adaptor frame on Node.js v12+
+  process.abort();       // Creates an exit frame.
+  return this;           // Force definition of |this|.
 }
 
-function eyecatcher() {
+// Force V8 to use an inferred name instead of saving the variable name as
+// FunctionName.
+let fnInferredName;
+fnInferredName = (() => function () {
   crasher();    // # args < # formal parameters inserts an adaptor frame.
+})();
+
+function Module() {
+  this.foo = "bar";
+}
+
+Module.prototype.fnInferredNamePrototype = function() {
+  fnInferredName();
+}
+
+function fnFunctionName() {
+  (new Module()).fnInferredNamePrototype();
   return this;  // Force definition of |this|.
 }
 
-eyecatcher();
+fnFunctionName();


### PR DESCRIPTION
Apparently, sometimes the FunctionName slot on ScopeInfo is filled with
the empty string instead of not existing. This commit changes our
heuristic to search for the first non-empty string on the first 3 slots
after the last context info slot on the ScopeInfo. This should be enough
to cover most (all?) cases.

Also updated frame-test to add frames to the stack which V8 will infer
the name instead of storing it directly, and changed this particular
test to use Promises instead of callbacks. We should be able to upgrade
tests to primise-based API gradually with this approach. When all tests
are promisified, we can change the api on test/common.js to be
promise-based instead of callback-based.