### PR TITLE
build: allow custom lldb headers path with npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ make plugin
 
 # To configure and build both the plugin and the addon
 npm install --llnode_build_addon=true
+# To configure and build with a specific path to headers
+npm install --llnode_lldb_include_dir=/path/to/lldb/include
+
 # Without npm
 LLNODE_BUILD_ADDON=true node scripts/configure.js && node scripts/install.js && node scripts/cleanup.js
 # Or use make

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -51,7 +51,8 @@ function configureInstallation(osName, buildDir) {
   // - What level of lldb we are running.
   // - If we need to download the headers. (Linux may have them installed)
   let installation;
-  let includeDir;
+  let includeDir = process.env.npm_config_llnode_lldb_include_dir ||
+    process.env.LLNODE_LLDB_INCLUDE_DIR;
   const config = {
     variables: {}
   };
@@ -82,11 +83,13 @@ function configureInstallation(osName, buildDir) {
     process.exit(1);
   }
 
-  if (installation.includeDir === undefined) {
-    // Could not find the headers, need to download them
-    includeDir = lldb.cloneHeaders(installation.version, buildDir);
-  } else {
-    includeDir = installation.includeDir;
+  if (!includeDir) {
+    if (installation.includeDir === undefined) {
+      // Could not find the headers, need to download them
+      includeDir = lldb.cloneHeaders(installation.version, buildDir);
+    } else {
+      includeDir = installation.includeDir;
+    }
   }
   config.variables['lldb_include_dir%'] = includeDir;
   return {

--- a/scripts/lldb.js
+++ b/scripts/lldb.js
@@ -146,7 +146,7 @@ function getLldbVersion(lldbExe) {
     return undefined;
   }
   // Ignore minor revisions like 3.8.1
-  const versionMatch = lldbStr.match(/version (\d.\d)/);
+  const versionMatch = lldbStr.match(/version (\d+.\d+)/);
   if (versionMatch) {
     return versionMatch[1];
   }


### PR DESCRIPTION
It's possible to set a custom lldb headers path if configuring the build
manually. This commit also allows users to do it when using
`npm install`. This is useful when using lldb built from source, for
example.