### PR TITLE
src: v12.x-compatible DescriptorArray

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1563,7 +1563,7 @@ bool FindJSObjectsVisitor::MapCacheEntry::Load(v8::Map map,
   if (is_histogram) type_name = heap_object.GetTypeName(err);
 
   v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return false;
+  RETURN_IF_INVALID(descriptors_obj, false);
 
   v8::DescriptorArray descriptors(descriptors_obj);
   own_descriptors_count_ = map.NumberOfOwnDescriptors(err);
@@ -1579,8 +1579,8 @@ bool FindJSObjectsVisitor::MapCacheEntry::Load(v8::Map map,
   }
 
   for (uint64_t i = 0; i < own_descriptors_count_; i++) {
-    v8::Value key = descriptors.GetKey(i, err);
-    if (err.Fail()) continue;
+    v8::Value key = descriptors.GetKey(i);
+    if (!key.Check()) continue;
     properties_.emplace_back(key.ToString(err));
   }
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -95,6 +95,7 @@ void Map::Load() {
                    "class_Map__constructor__Object");
   kInstanceDescriptorsOffset = LoadConstant({
       "class_Map__instance_descriptors__DescriptorArray",
+      "class_Map__instance_descriptors_offset",
   });
   kBitField3Offset =
       LoadConstant("class_Map__bit_field3__int", "class_Map__bit_field3__SMI");
@@ -403,9 +404,9 @@ void JSArrayBufferView::Load() {
 
 
 void DescriptorArray::Load() {
-  kDetailsOffset = LoadConstant("prop_desc_details");
-  kKeyOffset = LoadConstant("prop_desc_key");
-  kValueOffset = LoadConstant("prop_desc_value");
+  kDetailsOffset = LoadConstant({"prop_desc_details"});
+  kKeyOffset = LoadConstant({"prop_desc_key"});
+  kValueOffset = LoadConstant({"prop_desc_value"});
 
   kPropertyIndexMask = LoadConstant("prop_index_mask");
   kPropertyIndexShift = LoadConstant("prop_index_shift");
@@ -455,8 +456,12 @@ void DescriptorArray::Load() {
     kRepresentationDouble = 7;
   }
 
-  kFirstIndex = LoadConstant("prop_idx_first");
-  kSize = LoadConstant("prop_desc_size");
+  // NOTE(mmarchini): removed from V8 7.2.
+  // https://github.com/v8/v8/commit/1ad0cd5
+  kFirstIndex = LoadOptionalConstant({"prop_idx_first"}, 0);
+  kSize = LoadConstant({"prop_desc_size"});
+  kHeaderSize = LoadOptionalConstant(
+      {"class_DescriptorArray__header_size__uintptr_t"}, 0);
 }
 
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -406,9 +406,9 @@ class DescriptorArray : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(DescriptorArray);
 
-  int64_t kDetailsOffset;
-  int64_t kKeyOffset;
-  int64_t kValueOffset;
+  Constant<int64_t> kDetailsOffset;
+  Constant<int64_t> kKeyOffset;
+  Constant<int64_t> kValueOffset;
 
   int64_t kPropertyIndexMask;
   int64_t kPropertyIndexShift;
@@ -417,8 +417,10 @@ class DescriptorArray : public Module {
 
   int64_t kRepresentationDouble;
 
-  int64_t kFirstIndex;
-  int64_t kSize;
+  Constant<int64_t> kFirstIndex;
+  Constant<int64_t> kHeaderSize;
+  Constant<int64_t> kSize;
+  Constant<int64_t> kEntrySize;
 
   // node.js <= 7
   int64_t kPropertyTypeMask = -1;

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -455,11 +455,14 @@ class DescriptorArray : public FixedArray {
  public:
   V8_VALUE_DEFAULT_METHODS(DescriptorArray, FixedArray)
 
-  inline Smi GetDetails(int index, Error& err);
-  inline Value GetKey(int index, Error& err);
+  template <class T>
+  inline T Get(int index, int64_t offset);
+
+  inline Smi GetDetails(int index);
+  inline Value GetKey(int index);
 
   // NOTE: Only for DATA_CONSTANT
-  inline Value GetValue(int index, Error& err);
+  inline Value GetValue(int index);
 
   inline bool IsFieldDetails(Smi details);
   inline bool IsDescriptorDetails(Smi details);

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -467,9 +467,7 @@ std::string Printer::Stringify(v8::JSArrayBufferView js_array_buffer_view,
 
 template <>
 std::string Printer::Stringify(v8::Map map, Error& err) {
-  v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return std::string();
-
+  // TODO(mmarchini): don't fail if can't load NumberOfOwnDescriptors
   int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
   if (err.Fail()) return std::string();
 
@@ -492,25 +490,41 @@ std::string Printer::Stringify(v8::Map map, Error& err) {
   char tmp[256];
   std::stringstream ss;
   ss << rang::fg::yellow
-     << "<Map own_descriptors=%d %s=%d instance_size=%d "
-        "descriptors=0x%016" PRIx64
-     << rang::fg::reset;
+     << "<Map own_descriptors=%d %s=%d instance_size=%d descriptors=";
+
+  // TODO(mmarchini): this should be a reusable method
+  std::string descriptors_str = "???";
+  v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
+  if (descriptors_obj.Check()) {
+    char descriptors_raw[50];
+    snprintf(descriptors_raw, 50, "0x%016" PRIx64, descriptors_obj.raw());
+    ss << descriptors_raw;
+  } else {
+    PRINT_DEBUG("Failed to load InstanceDescriptors");
+    ss << rang::fg::red << "???";
+  }
+
+  ss << rang::fg::reset;
 
   snprintf(tmp, sizeof(tmp), ss.str().c_str(),
            static_cast<int>(own_descriptors_count),
            in_object_properties_or_constructor.c_str(),
            static_cast<int>(in_object_properties_or_constructor_index),
-           static_cast<int>(instance_size), descriptors_obj.raw());
+           static_cast<int>(instance_size));
 
   if (!options_.detailed) {
     return std::string(tmp) + ">";
   }
 
-  v8::DescriptorArray descriptors(descriptors_obj);
-  if (err.Fail()) return std::string();
+  if (descriptors_obj.Check()) {
+    v8::DescriptorArray descriptors(descriptors_obj);
+    if (err.Fail()) return std::string();
 
-  return std::string(tmp) + ":" + Stringify<v8::FixedArray>(descriptors, err) +
-         ">";
+    return std::string(tmp) + ":" +
+           Stringify<v8::FixedArray>(descriptors, err) + ">";
+  } else {
+    std::string(tmp) + ">";
+  }
 }
 
 template <>
@@ -965,7 +979,7 @@ std::string Printer::StringifyDictionary(v8::JSObject js_object, Error& err) {
 std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
                                           Error& err) {
   v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return std::string();
+  RETURN_IF_INVALID(descriptors_obj, std::string());
 
   v8::DescriptorArray descriptors(descriptors_obj);
   int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
@@ -987,26 +1001,37 @@ std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
   std::string res;
   std::stringstream ss;
   for (int64_t i = 0; i < own_descriptors_count; i++) {
-    v8::Smi details = descriptors.GetDetails(i, err);
-    if (err.Fail()) return std::string();
-
-    v8::Value key = descriptors.GetKey(i, err);
-    if (err.Fail()) return std::string();
-
     if (!res.empty()) res += ",\n";
+
+    v8::Value key = descriptors.GetKey(i);
 
     ss.str("");
     ss.clear();
-    ss << rang::style::bold << rang::fg::yellow << "    ." + key.ToString(err)
-       << rang::fg::reset << rang::style::reset;
+    ss << rang::style::bold << rang::fg::yellow << "    .";
+    if (key.Check()) {
+      ss << key.ToString(err);
+    } else {
+      PRINT_DEBUG("Failed to get key for index %ld", i);
+      ss << "???";
+    }
+    ss << rang::fg::reset << rang::style::reset;
+
     res += ss.str() + "=";
     if (err.Fail()) return std::string();
+
+    v8::Smi details = descriptors.GetDetails(i);
+    if (!details.Check()) {
+      PRINT_DEBUG("Failed to get details for index %ld", i);
+      res += "???";
+      continue;
+    }
 
     if (descriptors.IsConstFieldDetails(details) ||
         descriptors.IsDescriptorDetails(details)) {
       v8::Value value;
 
-      value = descriptors.GetValue(i, err);
+      value = descriptors.GetValue(i);
+      RETURN_IF_INVALID(value, std::string());
       if (err.Fail()) return std::string();
 
       res += printer.Stringify(value, err);


### PR DESCRIPTION
V8 changed DescriptorArray from a FixedArray to a proper HeapObject.
These changes update accessors for DescriptorArray fields to make them
compatible with FixedArray-like and HeapObject-like access.

Ref: https://github.com/nodejs/llnode/issues/255