### PR TITLE
test: update Error.stack test for V8 7.5

### DIFF
--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -173,7 +173,11 @@ const hashMapTests = {
         if (err) return cb(err);
         lines = lines.join('\n');
 
-        let strStackMatch = lines.match(/stack=(0x[0-9a-f]+):<String: /i);
+        // NOTE(mmarchini): V8 7.5 replaces the internal symbol with a string
+        // instead of the .stack accessor to avoid creating a new Map for each
+        // Error with stringified stack.
+        // https://github.com/v8/v8/commit/c8206043e1afb6d179a68bb5a8c079de5e76a010
+        let strStackMatch = lines.match(/(Symbol\(\)|stack)=(0x[0-9a-f]+):<String: /i);
         t.ok(strStackMatch, 'hashmap.stringifiedError should have stringified stack');
 
         let stackMatch  = lines.match(/error stack {/i);


### PR DESCRIPTION
V8 7.5 changed how it caches the stringified stack on Error objects
after the first access. Instead of replacing the accessor Error.stack
with the stringified stack, the stringified stack is stored in the same
Symbol which was used to store the FrameArray stack.

Ref: https://github.com/v8/v8/commit/c8206043e1afb6d179a68bb5a8c079de5e