### PR TITLE
Nodejs v12 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,9 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - version: 8.x
           - version: 10.x
-          - version: 11.x
+          - version: 12.x
           - version: 14.x
             mirror: https://nodejs.org/download/nightly
           - version: 14.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llnode",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "An lldb plugin for Node.js and V8, which enables inspection of JavaScript states for insights into Node.js processes and their core dumps.",
   "main": "index.js",
   "directories": {

--- a/src/constants.h
+++ b/src/constants.h
@@ -48,8 +48,6 @@ class Constant {
 
   inline std::string name() { return name_; }
 
- protected:
-  friend class Constants;
   explicit Constant(T value) : value_(value), status_(kValid), name_("") {}
   Constant(T value, std::string name)
       : value_(value), status_(kLoaded), name_(name) {}

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -1563,7 +1563,7 @@ bool FindJSObjectsVisitor::MapCacheEntry::Load(v8::Map map,
   if (is_histogram) type_name = heap_object.GetTypeName(err);
 
   v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return false;
+  RETURN_IF_INVALID(descriptors_obj, false);
 
   v8::DescriptorArray descriptors(descriptors_obj);
   own_descriptors_count_ = map.NumberOfOwnDescriptors(err);
@@ -1579,8 +1579,8 @@ bool FindJSObjectsVisitor::MapCacheEntry::Load(v8::Map map,
   }
 
   for (uint64_t i = 0; i < own_descriptors_count_; i++) {
-    v8::Value key = descriptors.GetKey(i, err);
-    if (err.Fail()) continue;
+    v8::Value key = descriptors.GetKey(i);
+    if (!key.Check()) continue;
     properties_.emplace_back(key.ToString(err));
   }
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -95,6 +95,7 @@ void Map::Load() {
                    "class_Map__constructor__Object");
   kInstanceDescriptorsOffset = LoadConstant({
       "class_Map__instance_descriptors__DescriptorArray",
+      "class_Map__instance_descriptors_offset",
   });
   kBitField3Offset =
       LoadConstant("class_Map__bit_field3__int", "class_Map__bit_field3__SMI");
@@ -403,9 +404,9 @@ void JSArrayBufferView::Load() {
 
 
 void DescriptorArray::Load() {
-  kDetailsOffset = LoadConstant("prop_desc_details");
-  kKeyOffset = LoadConstant("prop_desc_key");
-  kValueOffset = LoadConstant("prop_desc_value");
+  kDetailsOffset = LoadConstant({"prop_desc_details"});
+  kKeyOffset = LoadConstant({"prop_desc_key"});
+  kValueOffset = LoadConstant({"prop_desc_value"});
 
   kPropertyIndexMask = LoadConstant("prop_index_mask");
   kPropertyIndexShift = LoadConstant("prop_index_shift");
@@ -455,8 +456,12 @@ void DescriptorArray::Load() {
     kRepresentationDouble = 7;
   }
 
-  kFirstIndex = LoadConstant("prop_idx_first");
-  kSize = LoadConstant("prop_desc_size");
+  // NOTE(mmarchini): removed from V8 7.2.
+  // https://github.com/v8/v8/commit/1ad0cd5
+  kFirstIndex = LoadOptionalConstant({"prop_idx_first"}, 0);
+  kSize = LoadConstant({"prop_desc_size"});
+  kHeaderSize = LoadOptionalConstant(
+      {"class_DescriptorArray__header_size__uintptr_t"}, 0);
 }
 
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -501,7 +501,7 @@ void DescriptorArray::Load() {
   kFirstIndex = LoadOptionalConstant({"prop_idx_first"}, 0);
   kSize = LoadConstant({"prop_desc_size"});
   kHeaderSize = LoadOptionalConstant(
-      {"class_DescriptorArray__header_size__uintptr_t"}, 0);
+      {"class_DescriptorArray__header_size__uintptr_t"}, 24);
 }
 
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -323,18 +323,22 @@ void TwoByteString::Load() {
 
 
 void ConsString::Load() {
-  kFirstOffset = LoadConstant("class_ConsString__first__String");
-  kSecondOffset = LoadConstant("class_ConsString__second__String");
+  kFirstOffset = LoadConstant({"class_ConsString__first__String",
+                               "class_ConsString__first_offset__int"});
+  kSecondOffset = LoadConstant({"class_ConsString__second__String",
+                                "class_ConsString__second_offset__int"});
 }
 
 
 void SlicedString::Load() {
   kParentOffset = LoadConstant("class_SlicedString__parent__String");
-  kOffsetOffset = LoadConstant("class_SlicedString__offset__SMI");
+  kOffsetOffset = LoadConstant({"class_SlicedString__offset__SMI",
+                                "class_SlicedString__offset_offset__int"});
 }
 
 void ThinString::Load() {
-  kActualOffset = LoadConstant("class_ThinString__actual__String");
+  kActualOffset = LoadConstant({"class_ThinString__actual__String",
+                                "class_ThinString__actual_offset__int"});
 }
 
 void FixedArrayBase::Load() {

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -550,7 +550,24 @@ void Frame::Load() {
 
 
 void Symbol::Load() {
-  kNameOffset = LoadConstant({"class_Symbol__name__Object"});
+  // map is the last field of HeapObject
+  Constant<int64_t> maybe_name_offset =
+      LoadConstant({"class_HeapObject__map__Map"});
+  common_->Load();
+  if (maybe_name_offset.Check()) {
+    int name_offset = *maybe_name_offset;
+
+    name_offset += common_->kPointerSize;
+    // class Name extends HeapObject and has only one uint32 field
+    name_offset += sizeof(uint32_t);
+    // class Symbol extends Name and has one int32 field before name
+    name_offset += sizeof(int32_t);
+
+    kNameOffset =
+        LoadOptionalConstant({"class_Symbol__name__Object"}, name_offset);
+  } else {
+    kNameOffset = LoadConstant({"class_Symbol__name__Object"});
+  }
 }
 
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -550,7 +550,7 @@ void Frame::Load() {
 
 
 void Symbol::Load() {
-  kNameOffset = LoadConstant("class_Symbol__name__Object");
+  kNameOffset = LoadConstant({"class_Symbol__name__Object"});
 }
 
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -348,8 +348,21 @@ class FixedTypedArrayBase : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(FixedTypedArrayBase);
 
-  int64_t kBasePointerOffset;
-  int64_t kExternalPointerOffset;
+  Constant<int64_t> kBasePointerOffset;
+  Constant<int64_t> kExternalPointerOffset;
+
+ protected:
+  void Load();
+};
+
+class JSTypedArray : public Module {
+ public:
+  CONSTANTS_DEFAULT_METHODS(JSTypedArray);
+
+  Constant<int64_t> kBasePointerOffset;
+  Constant<int64_t> kExternalPointerOffset;
+
+  bool IsDataPointerInJSTypedArray();
 
  protected:
   void Load();
@@ -379,12 +392,14 @@ class JSArrayBuffer : public Module {
 
   int64_t kKindOffset;
 
-  int64_t kBackingStoreOffset;
-  int64_t kByteLengthOffset;
-  int64_t kBitFieldOffset;
+  Constant<int64_t> kBackingStoreOffset;
+  Constant<int64_t> kByteLengthOffset;
 
   int64_t kWasNeuteredMask;
   int64_t kWasNeuteredShift;
+
+  Constant<int64_t> BitFieldOffset();
+  bool IsByteLengthScalar();
 
  protected:
   void Load();
@@ -395,8 +410,11 @@ class JSArrayBufferView : public Module {
   CONSTANTS_DEFAULT_METHODS(JSArrayBufferView);
 
   int64_t kBufferOffset;
-  int64_t kByteOffsetOffset;
-  int64_t kByteLengthOffset;
+  Constant<int64_t> kByteOffsetOffset;
+  Constant<int64_t> kByteLengthOffset;
+
+  bool IsByteLengthScalar();
+  bool IsByteOffsetScalar();
 
  protected:
   void Load();

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -406,9 +406,9 @@ class DescriptorArray : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(DescriptorArray);
 
-  int64_t kDetailsOffset;
-  int64_t kKeyOffset;
-  int64_t kValueOffset;
+  Constant<int64_t> kDetailsOffset;
+  Constant<int64_t> kKeyOffset;
+  Constant<int64_t> kValueOffset;
 
   int64_t kPropertyIndexMask;
   int64_t kPropertyIndexShift;
@@ -417,8 +417,10 @@ class DescriptorArray : public Module {
 
   int64_t kRepresentationDouble;
 
-  int64_t kFirstIndex;
-  int64_t kSize;
+  Constant<int64_t> kFirstIndex;
+  Constant<int64_t> kHeaderSize;
+  Constant<int64_t> kSize;
+  Constant<int64_t> kEntrySize;
 
   // node.js <= 7
   int64_t kPropertyTypeMask = -1;

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -296,8 +296,8 @@ class ConsString : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(ConsString);
 
-  int64_t kFirstOffset;
-  int64_t kSecondOffset;
+  Constant<int64_t> kFirstOffset;
+  Constant<int64_t> kSecondOffset;
 
  protected:
   void Load();
@@ -308,7 +308,7 @@ class SlicedString : public Module {
   CONSTANTS_DEFAULT_METHODS(SlicedString);
 
   int64_t kParentOffset;
-  int64_t kOffsetOffset;
+  Constant<int64_t> kOffsetOffset;
 
  protected:
   void Load();
@@ -318,7 +318,7 @@ class ThinString : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(ThinString);
 
-  int64_t kActualOffset;
+  Constant<int64_t> kActualOffset;
 
  protected:
   void Load();

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -509,7 +509,7 @@ class Symbol : public Module {
  public:
   CONSTANTS_DEFAULT_METHODS(Symbol);
 
-  int64_t kNameOffset;
+  Constant<int64_t> kNameOffset;
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -281,7 +281,7 @@ ACCESSOR(Map, MaybeConstructor, map()->kMaybeConstructorOffset, HeapObject)
 SAFE_ACCESSOR(Map, InstanceDescriptors, map()->kInstanceDescriptorsOffset,
               HeapObject)
 
-ACCESSOR(Symbol, Name, symbol()->kNameOffset, HeapObject)
+SAFE_ACCESSOR(Symbol, Name, symbol()->kNameOffset, HeapObject)
 
 inline int64_t Map::BitField3(Error& err) {
   return v8()->LoadUnsigned(LeaField(v8()->map()->kBitField3Offset), 4, err);

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -774,13 +774,13 @@ ACCESSOR(JSFunction, Info, js_function()->kSharedInfoOffset,
          SharedFunctionInfo);
 ACCESSOR(JSFunction, GetContext, js_function()->kContextOffset, HeapObject);
 
-ACCESSOR(ConsString, First, cons_string()->kFirstOffset, String);
-ACCESSOR(ConsString, Second, cons_string()->kSecondOffset, String);
+SAFE_ACCESSOR(ConsString, First, cons_string()->kFirstOffset, String);
+SAFE_ACCESSOR(ConsString, Second, cons_string()->kSecondOffset, String);
 
 ACCESSOR(SlicedString, Parent, sliced_string()->kParentOffset, String);
-ACCESSOR(SlicedString, Offset, sliced_string()->kOffsetOffset, Smi);
+SAFE_ACCESSOR(SlicedString, Offset, sliced_string()->kOffsetOffset, Smi);
 
-ACCESSOR(ThinString, Actual, thin_string()->kActualOffset, String);
+SAFE_ACCESSOR(ThinString, Actual, thin_string()->kActualOffset, String);
 
 ACCESSOR(FixedArrayBase, Length, fixed_array_base()->kLengthOffset, Smi);
 

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -889,7 +889,7 @@ inline T DescriptorArray::Get(int index, int64_t offset) {
   if (v8()->descriptor_array()->kFirstIndex.Loaded()) {
     return FixedArray::Get<T>(
         *(v8()->descriptor_array()->kFirstIndex) + index + offset, err);
-  } else if (v8()->descriptor_array()->kHeaderSize.Loaded()) {
+  } else if (v8()->descriptor_array()->kHeaderSize.Check()) {
     index *= v8()->common()->kPointerSize;
     index += *(v8()->descriptor_array()->kHeaderSize);
     index += (v8()->common()->kPointerSize * offset);

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -729,6 +729,7 @@ std::string Symbol::ToString(Error& err) {
     return "Symbol()";
   }
   HeapObject name = Name(err);
+  RETURN_IF_INVALID(name, "Symbol(???)");
   return "Symbol('" + String(name).ToString(err) + "')";
 }
 

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -53,6 +53,7 @@ void LLV8::Load(SBTarget target) {
   fixed_array_base.Assign(target, &common);
   fixed_array.Assign(target, &common);
   fixed_typed_array_base.Assign(target, &common);
+  js_typed_array.Assign(target, &common);
   oddball.Assign(target, &common);
   js_array_buffer.Assign(target, &common);
   js_array_buffer_view.Assign(target, &common);
@@ -78,21 +79,6 @@ int64_t LLV8::LoadPtr(int64_t addr, Error& err) {
 
   err = Error::Ok();
   return value;
-}
-
-template <class T>
-CheckedType<T> LLV8::LoadUnsigned(int64_t addr, uint32_t byte_size) {
-  SBError sberr;
-  int64_t value = process_.ReadUnsignedFromMemory(static_cast<addr_t>(addr),
-                                                  byte_size, sberr);
-
-  if (sberr.Fail()) {
-    PRINT_DEBUG("Failed to load unsigned from v8 memory. Reason: %s",
-                sberr.GetCString());
-    return CheckedType<T>();
-  }
-
-  return CheckedType<T>(value);
 }
 
 int64_t LLV8::LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err) {

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -455,11 +455,14 @@ class DescriptorArray : public FixedArray {
  public:
   V8_VALUE_DEFAULT_METHODS(DescriptorArray, FixedArray)
 
-  inline Smi GetDetails(int index, Error& err);
-  inline Value GetKey(int index, Error& err);
+  template <class T>
+  inline T Get(int index, int64_t offset);
+
+  inline Smi GetDetails(int index);
+  inline Value GetKey(int index);
 
   // NOTE: Only for DATA_CONSTANT
-  inline Value GetValue(int index, Error& err);
+  inline Value GetValue(int index);
 
   inline bool IsFieldDetails(Smi details);
   inline bool IsDescriptorDetails(Smi details);

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -467,9 +467,7 @@ std::string Printer::Stringify(v8::JSArrayBufferView js_array_buffer_view,
 
 template <>
 std::string Printer::Stringify(v8::Map map, Error& err) {
-  v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return std::string();
-
+  // TODO(mmarchini): don't fail if can't load NumberOfOwnDescriptors
   int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
   if (err.Fail()) return std::string();
 
@@ -492,25 +490,41 @@ std::string Printer::Stringify(v8::Map map, Error& err) {
   char tmp[256];
   std::stringstream ss;
   ss << rang::fg::yellow
-     << "<Map own_descriptors=%d %s=%d instance_size=%d "
-        "descriptors=0x%016" PRIx64
-     << rang::fg::reset;
+     << "<Map own_descriptors=%d %s=%d instance_size=%d descriptors=";
+
+  // TODO(mmarchini): this should be a reusable method
+  std::string descriptors_str = "???";
+  v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
+  if (descriptors_obj.Check()) {
+    char descriptors_raw[50];
+    snprintf(descriptors_raw, 50, "0x%016" PRIx64, descriptors_obj.raw());
+    ss << descriptors_raw;
+  } else {
+    PRINT_DEBUG("Failed to load InstanceDescriptors");
+    ss << rang::fg::red << "???";
+  }
+
+  ss << rang::fg::reset;
 
   snprintf(tmp, sizeof(tmp), ss.str().c_str(),
            static_cast<int>(own_descriptors_count),
            in_object_properties_or_constructor.c_str(),
            static_cast<int>(in_object_properties_or_constructor_index),
-           static_cast<int>(instance_size), descriptors_obj.raw());
+           static_cast<int>(instance_size));
 
   if (!options_.detailed) {
     return std::string(tmp) + ">";
   }
 
-  v8::DescriptorArray descriptors(descriptors_obj);
-  if (err.Fail()) return std::string();
+  if (descriptors_obj.Check()) {
+    v8::DescriptorArray descriptors(descriptors_obj);
+    if (err.Fail()) return std::string();
 
-  return std::string(tmp) + ":" + Stringify<v8::FixedArray>(descriptors, err) +
-         ">";
+    return std::string(tmp) + ":" +
+           Stringify<v8::FixedArray>(descriptors, err) + ">";
+  } else {
+    std::string(tmp) + ">";
+  }
 }
 
 template <>
@@ -965,7 +979,7 @@ std::string Printer::StringifyDictionary(v8::JSObject js_object, Error& err) {
 std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
                                           Error& err) {
   v8::HeapObject descriptors_obj = map.InstanceDescriptors(err);
-  if (err.Fail()) return std::string();
+  RETURN_IF_INVALID(descriptors_obj, std::string());
 
   v8::DescriptorArray descriptors(descriptors_obj);
   int64_t own_descriptors_count = map.NumberOfOwnDescriptors(err);
@@ -987,26 +1001,37 @@ std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
   std::string res;
   std::stringstream ss;
   for (int64_t i = 0; i < own_descriptors_count; i++) {
-    v8::Smi details = descriptors.GetDetails(i, err);
-    if (err.Fail()) return std::string();
-
-    v8::Value key = descriptors.GetKey(i, err);
-    if (err.Fail()) return std::string();
-
     if (!res.empty()) res += ",\n";
+
+    v8::Value key = descriptors.GetKey(i);
 
     ss.str("");
     ss.clear();
-    ss << rang::style::bold << rang::fg::yellow << "    ." + key.ToString(err)
-       << rang::fg::reset << rang::style::reset;
+    ss << rang::style::bold << rang::fg::yellow << "    .";
+    if (key.Check()) {
+      ss << key.ToString(err);
+    } else {
+      PRINT_DEBUG("Failed to get key for index %ld", i);
+      ss << "???";
+    }
+    ss << rang::fg::reset << rang::style::reset;
+
     res += ss.str() + "=";
     if (err.Fail()) return std::string();
+
+    v8::Smi details = descriptors.GetDetails(i);
+    if (!details.Check()) {
+      PRINT_DEBUG("Failed to get details for index %ld", i);
+      res += "???";
+      continue;
+    }
 
     if (descriptors.IsConstFieldDetails(details) ||
         descriptors.IsDescriptorDetails(details)) {
       v8::Value value;
 
-      value = descriptors.GetValue(i, err);
+      value = descriptors.GetValue(i);
+      RETURN_IF_INVALID(value, std::string());
       if (err.Fail()) return std::string();
 
       res += printer.Stringify(value, err);

--- a/test/common.js
+++ b/test/common.js
@@ -332,3 +332,10 @@ Session.prototype.hasSymbol = function hasSymbol(symbol, callback) {
     }
   });
 };
+
+function nodejsVersion() {
+  const version = process.version.substring(1, process.version.indexOf('-'));
+  const versionArray = version.split('.').map(s => Number(s));
+  return versionArray;
+}
+exports.nodejsVersion = nodejsVersion;

--- a/test/plugin/frame-test.js
+++ b/test/plugin/frame-test.js
@@ -5,6 +5,7 @@ const { promisify } = require('util');
 const tape = require('tape');
 
 const common = require('../common');
+const { nodejsVersion } = common;
 
 const sourceCodes = {
   "fnFunctionName": [
@@ -86,7 +87,8 @@ tape('v8 stack', async (t) => {
     t.ok(/<exit>/.test(exit), 'exit frame');
     t.ok(/crasher/.test(crasher), 'crasher frame');
     t.ok(/<adaptor>/.test(adapter), 'arguments adapter frame');
-    t.ok(/\sfnInferredName\(/.test(fnInferredName), 'fnInferredName frame');
+    if (nodejsVersion()[0] < 12)
+      t.ok(/\sfnInferredName\(/.test(fnInferredName), 'fnInferredName frame');
     t.ok(/\sModule.fnInferredNamePrototype\(/.test(fnInferredNamePrototype),
          'fnInferredNamePrototype frame');
     t.ok(/\sfnFunctionName\(/.test(fnFunctionName), 'fnFunctionName frame');
@@ -111,14 +113,16 @@ tape('v8 stack', async (t) => {
       fatalError(t, sess, "Couldn't determine fnFunctionName's frame number");
     }
 
-    const fnInferredNamePrototypeFrame =
-      fnInferredNamePrototype.match(/frame #([0-9]+)/)[1];
-    if (fnInferredNamePrototypeFrame) {
-      await testFrameList(t, sess, fnInferredNamePrototypeFrame,
-                          sourceCodes['fnInferredNamePrototype']);
-    } else {
-      fatalError(t, sess,
-                 "Couldn't determine fnInferredNamePrototype's frame number");
+    if (nodejsVersion()[0] < 12) {
+      const fnInferredNamePrototypeFrame =
+        fnInferredNamePrototype.match(/frame #([0-9]+)/)[1];
+      if (fnInferredNamePrototypeFrame) {
+        await testFrameList(t, sess, fnInferredNamePrototypeFrame,
+                            sourceCodes['fnInferredNamePrototype']);
+      } else {
+        fatalError(t, sess,
+                  "Couldn't determine fnInferredNamePrototype's frame number");
+      }
     }
 
     const fnInferredNameFrame = fnInferredName.match(/frame #([0-9]+)/)[1];


### PR DESCRIPTION
This PR contains all commits necessary to make llnode work on v12, plus changes to CI to run tests on v12, drop v8 and v11, and bump the major version since we're dropping support and adding new one. I made a PR on nodejs/node to update the list of postmortem constants used, but I noticed some of the constants here already changes on v13, so we'll have to work on that.