### PR TITLE
meta: add policy to land PRs without approval

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -9,3 +9,6 @@ with the following differences:
   - There's no minimum wait time for landing a pull request. Pull requests can
     land as soon as they get approved by at least one Collaborator.
   - Approval must be from Collaborators who are not authors of the change.
+  - If the pull request was open for three days (72 hours) without reviews, and
+    it was opened by a llnode Collaborator, the pull request can land without
+    approvals.


### PR DESCRIPTION
As discussed in the 2020-02-12 Diagnostics WG Meeting and suggested in
https://github.com/nodejs/llnode/issues/242#issuecomment-430369666,
change the landing policy so that Collaborators can land pull requests
if it was open for three days and there were no reviews on it.

Ref: https://github.com/nodejs/diagnostics/issues/355