### PR TITLE
src: fix getopt format string

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -62,7 +62,7 @@ char** ParsePrinterOptions(char** cmd, Printer::PrinterOptions* options) {
   optind = 0;
   opterr = 1;
   do {
-    int arg = getopt_long(argc, args, "Fmsdvln:", opts, nullptr);
+    int arg = getopt_long(argc, args, "Fmsdvl:n:", opts, nullptr);
     if (arg == -1) break;
 
     switch (arg) {

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -208,7 +208,7 @@ const hashMapTests = {
     desc: '.long-array JSArray property',
     validator(t, sess, addresses, name, cb) {
       const address = addresses[name];
-      sess.send(`v8 inspect --array-length 10 ${address}`);
+      sess.send(`v8 inspect -l 10 ${address}`);
 
       sess.linesUntil(/}>/, (err, lines) => {
         if (err) return cb(err);


### PR DESCRIPTION
`v8 inspect -l <n>` takes an argument.

Bug introduced in commit 2fc1571 ("src: option to limit output
of `findjsinstances`") from September 2018.

Fixes: https://github.com/nodejs/llnode/issues/346