### PR TITLE
src: improve Error message on LoadPtr

### DIFF
--- a/llnode.gypi
+++ b/llnode.gypi
@@ -26,6 +26,9 @@
       "Debug": {
         "defines": [ "DEBUG", "_DEBUG" ],
         "cflags": [ "-g", "-O0", "-fwrapv" ],
+        "cflags_cc!": [
+          "-fno-rtti"
+        ],
         "xcode_settings": {
           "GCC_OPTIMIZATION_LEVEL": "0"
         },

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -60,7 +60,13 @@ inline T LLV8::LoadValue(int64_t addr, Error& err) {
   if (!res.Check()) {
     // TODO(joyeecheung): use Error::Failure() to report information when
     // there is less noise from here.
-    err = Error(true, "Invalid value");
+#if DEBUG
+#define _s typeid(T).name()
+#else
+#define _s "value"
+#endif
+    err = Error(true, "The value %lx is not a valid %s", addr, _s);
+#undef _s
     return T();
   }
 


### PR DESCRIPTION
Knowing why LoadPtr failed can be quite helpful when debugging llnode,
but the current message doesn't give any additional information. Sharing
the address llnode tried to load, as well as the supposed type for that
address makes debugging easier. The type name is only shown on Debug
builds.