### PR TITLE
src: update SFI script accessor for V8 8.1

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -197,8 +197,9 @@ void SharedInfo::Load() {
       LoadConstant("class_SharedFunctionInfo__inferred_name__String",
                    "class_SharedFunctionInfo__function_identifier__Object");
   kScriptOffset = LoadConstant("class_SharedFunctionInfo__script__Object");
-  kScriptOrDebugInfoOffset =
-      LoadConstant("class_SharedFunctionInfo__script_or_debug_info__Object");
+  kScriptOrDebugInfoOffset = LoadConstant(
+      {"class_SharedFunctionInfo__script_or_debug_info__Object",
+       "class_SharedFunctionInfo__script_or_debug_info__HeapObject"});
   kStartPositionOffset =
       LoadConstant("class_SharedFunctionInfo__start_position_and_type__int",
                    "class_SharedFunctionInfo__start_position_and_type__SMI");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -157,7 +157,7 @@ class SharedInfo : public Module {
   int64_t kNameOffset;
   int64_t kInferredNameOffset;
   int64_t kScriptOffset;
-  int64_t kScriptOrDebugInfoOffset;
+  Constant<int64_t> kScriptOrDebugInfoOffset;
   int64_t kStartPositionOffset;
   int64_t kEndPositionOffset;
   int64_t kParameterCountOffset;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -444,8 +444,8 @@ ACCESSOR(SharedFunctionInfo, name, shared_info()->kNameOffset, String)
 ACCESSOR(SharedFunctionInfo, inferred_name, shared_info()->kInferredNameOffset,
          Value)
 ACCESSOR(SharedFunctionInfo, script, shared_info()->kScriptOffset, Script)
-ACCESSOR(SharedFunctionInfo, script_or_debug_info,
-         shared_info()->kScriptOrDebugInfoOffset, HeapObject)
+SAFE_ACCESSOR(SharedFunctionInfo, script_or_debug_info,
+              shared_info()->kScriptOrDebugInfoOffset, HeapObject)
 ACCESSOR(SharedFunctionInfo, scope_info, shared_info()->kScopeInfoOffset,
          HeapObject)
 ACCESSOR(SharedFunctionInfo, name_or_scope_info,
@@ -493,7 +493,9 @@ HeapObject SharedFunctionInfo::GetScopeInfo(Error& err) {
 }
 
 Script SharedFunctionInfo::GetScript(Error& err) {
-  if (v8()->shared_info()->kScriptOrDebugInfoOffset == -1) return script(err);
+  if (!v8()->shared_info()->kScriptOrDebugInfoOffset.Loaded()) {
+    return script(err);
+  }
 
   HeapObject maybe_script = script_or_debug_info(err);
   if (maybe_script.IsScript(err)) return maybe_script;


### PR DESCRIPTION
The metadata used to access the script field from an SFI changed on V8
8.1. The field is still the same, so no other changes are necessary.
This fixes `v8 bt` on 8.1, as well as `stack-test` suite.