### PR TITLE
src: boxed double fields for V8 8.1

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -1,11 +1,17 @@
 #ifndef SRC_ERROR_H_
 #define SRC_ERROR_H_
 
+#include <iostream>
 #include <string>
 #include <typeinfo>
 
 #define PRINT_DEBUG(format, ...) \
   Error::PrintInDebugMode(__FILE__, __LINE__, __func__, format, ##__VA_ARGS__)
+
+[[noreturn]] inline void unreachable() {
+  std::cerr << "unreachable" << std::endl;
+  std::abort();
+}
 
 namespace llnode {
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -128,8 +128,24 @@ void Map::Load() {
     kNumberOfOwnDescriptorsMask = (1 << kDescriptorIndexBitCount) - 1;
     kNumberOfOwnDescriptorsMask <<= kNumberOfOwnDescriptorsShift;
   }
+  kLayoutDescriptor =
+      LoadConstant({"class_Map__layout_descriptor__LayoutDescriptor"});
 }
 
+
+bool Map::HasUnboxedDoubleFields() {
+  // LayoutDescriptor is used by V8 to define which fields are not tagged
+  // (unboxed). In preparation for pointer compressions, V8 disabled unboxed
+  // doubles everywhere, which means Map doesn't have a layout_descriptor
+  // field, but because of how gen-postmortem-metadata works and how Torque
+  // generates the offsets file, we get a constant for it anyway. In the future
+  // unboxing will be enabled again, in which case this field will be used.
+  // Until then, we use the presence of this field as version (if the field is
+  // present, it's safe to assume we're on V8 8.1+, at least on supported
+  // release lines).
+  return kLayoutDescriptor.name() !=
+         "v8dbg_class_Map__layout_descriptor__LayoutDescriptor";
+}
 
 void JSObject::Load() {
   kPropertiesOffset =

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -143,8 +143,7 @@ bool Map::HasUnboxedDoubleFields() {
   // Until then, we use the presence of this field as version (if the field is
   // present, it's safe to assume we're on V8 8.1+, at least on supported
   // release lines).
-  return kLayoutDescriptor.name() !=
-         "v8dbg_class_Map__layout_descriptor__LayoutDescriptor";
+  return !kLayoutDescriptor.Loaded();
 }
 
 void JSObject::Load() {

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -77,10 +77,13 @@ class Map : public Module {
   int64_t kInObjectPropertiesStartOffset;
   int64_t kInstanceSizeOffset;
   int64_t kInstanceTypeOffset;
+  Constant<int64_t> kLayoutDescriptor;
 
   int64_t kNumberOfOwnDescriptorsMask;
   int64_t kNumberOfOwnDescriptorsShift;
   int64_t kDictionaryMapShift;
+
+  bool HasUnboxedDoubleFields();
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -405,8 +405,16 @@ inline HeapNumber JSObject::GetDoubleField(int64_t index, Error err) {
     // When unboxed doubles are not allowed, all double fields are stored as
     // HeapNumber objects.
     if (v8()->map()->HasUnboxedDoubleFields()) {
-      return HeapNumber(v8(),
-                        GetInObjectValue<double>(instance_size, index, err));
+      // TODO(mmarchini): GetInObjectValue call chain should be
+      // CheckedType-aware instead of relying on Error.
+      Error get_in_object_value_err;
+      double result = GetInObjectValue<double>(instance_size, index,
+                                               get_in_object_value_err);
+      if (get_in_object_value_err.Fail()) {
+        return HeapNumber(v8(), CheckedType<double>());
+      } else {
+        return HeapNumber(v8(), CheckedType<double>(result));
+      }
     }
     return GetInObjectValue<HeapNumber>(instance_size, index, err);
   }

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -1031,7 +1031,6 @@ std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
 
     if (descriptors.IsDoubleField(details)) {
       v8::HeapNumber value = js_object.GetDoubleField(index, err);
-      RETURN_IF_INVALID(value, std::string());
 
       Error value_err;
       res += value.ToString(true, value_err);

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -1030,17 +1030,11 @@ std::string Printer::StringifyDescriptors(v8::JSObject js_object, v8::Map map,
     int64_t index = descriptors.FieldIndex(details) - in_object_count;
 
     if (descriptors.IsDoubleField(details)) {
-      double value;
-      if (index < 0)
-        value = js_object.GetInObjectValue<double>(instance_size, index, err);
-      else
-        value = extra_properties.Get<double>(index, err);
+      v8::HeapNumber value = js_object.GetDoubleField(index, err);
+      RETURN_IF_INVALID(value, std::string());
 
-      if (err.Fail()) return std::string();
-
-      char tmp[100];
-      snprintf(tmp, sizeof(tmp), "%f", value);
-      res += tmp;
+      Error value_err;
+      res += value.ToString(true, value_err);
     } else {
       v8::Value value;
       if (index < 0)


### PR DESCRIPTION
V8 8.1 disabled unboxed double fieds, which means all double fields are
now stored on memory as references to HeapNumber objects instead of the
double value. In theory V8 could store boxed doubles before, but we
didn't take it into account in our dobule fields code. In the future, V8
intends to re-enable unboxed doubles, which means we'll need to add
logic to handle both types of fields in the same llnode session.

This also fixes a bug where llnode was not handling double fields at all
in some cases.

Fixes: https://github.com/nodejs/llnode/issues/353
Signed-off-by: Matheus Marchini <mmarchini@netflix.com>