### PR TITLE
 src: update RegExp type constant for V8 8.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,9 @@ jobs:
           - version: 10.x
           - version: 12.x
           - version: 14.x
+          - version: 15.x
             mirror: https://nodejs.org/download/nightly
-          - version: 14.x
+          - version: 15.x
             mirror: https://nodejs.org/download/v8-canary
         os: [ubuntu-latest, macos-latest]
     steps:
@@ -40,19 +41,19 @@ jobs:
           npm install --llnode_build_addon=true --llnode_coverage=true
       - name: run tests
         run: TEST_LLDB_BINARY=`which lldb-3.9` npm run nyc-test-all
-        if: matrix.node.version != '14.x'
+        if: matrix.node.version != '15.x'
       - name: run tests (nightly)
         run: TEST_LLDB_BINARY=`which lldb-3.9` npm run nyc-test-all
-        if: matrix.node.version == '14.x'
+        if: matrix.node.version == '15.x'
         continue-on-error: true
       - name: prepare coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node.version != '14.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.node.version != '15.x'
         run: |
           npm run coverage
           cat ./coverage-js.info > ./coverage.info
           cat ./coverage-cc.info >> ./coverage.info
       - name: coveralls
-        if: matrix.os == 'ubuntu-latest' && matrix.node.version != '14.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.node.version != '15.x'
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: ./coverage.info

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -619,7 +619,8 @@ void Types::Load() {
   kFixedArrayType = LoadConstant("type_FixedArray__FIXED_ARRAY_TYPE");
   kJSArrayBufferType = LoadConstant("type_JSArrayBuffer__JS_ARRAY_BUFFER_TYPE");
   kJSTypedArrayType = LoadConstant("type_JSTypedArray__JS_TYPED_ARRAY_TYPE");
-  kJSRegExpType = LoadConstant("type_JSRegExp__JS_REGEXP_TYPE");
+  kJSRegExpType = LoadConstant(
+      {"type_JSRegExp__JS_REG_EXP_TYPE", "type_JSRegExp__JS_REGEXP_TYPE"});
   kJSDateType = LoadConstant("type_JSDate__JS_DATE_TYPE");
   kSharedFunctionInfoType =
       LoadConstant("type_SharedFunctionInfo__SHARED_FUNCTION_INFO_TYPE");

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -545,7 +545,7 @@ class Types : public Module {
   int64_t kFixedArrayType;
   int64_t kJSArrayBufferType;
   int64_t kJSTypedArrayType;
-  int64_t kJSRegExpType;
+  Constant<int64_t> kJSRegExpType;
   int64_t kJSDateType;
   int64_t kSharedFunctionInfoType;
   Constant<int64_t> kUncompiledDataWithoutPreParsedScopeType;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -660,7 +660,7 @@ std::string HeapObject::GetTypeName(Error& err) {
     return "(Function)";
   }
 
-  if (type == v8()->types()->kJSRegExpType) {
+  if (type == *v8()->types()->kJSRegExpType) {
     return "(RegExp)";
   }
 

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -726,7 +726,7 @@ std::string Printer::Stringify(v8::HeapObject heap_object, Error& err) {
     return pre + Stringify(fn, err);
   }
 
-  if (type == llv8_->types()->kJSRegExpType) {
+  if (type == *llv8_->types()->kJSRegExpType) {
     v8::JSRegExp re(heap_object);
     return pre + Stringify(re, err);
   }


### PR DESCRIPTION
This is the last change needed to support Node.js v14.