### PR TITLE
docs: fix macos install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ version is LLDB 3.9 and above.
   - Optionally, you can install newer versions of lldb using Homebrew with
 
     ```bash
-    brew update && brew install --with-lldb --with-toolchain llvm
+    brew update && brew install llvm
     ```
 
     and make sure `/usr/local/opt/llvm/bin` gets searched before `/usr/bin/`


### PR DESCRIPTION
`--with-lldb --with-toolchain` are removed from https://github.com/Homebrew/homebrew-core/blob/master/Formula/llvm.rb