### PR TITLE
Compilation warnings

### DIFF
--- a/llnode.gypi
+++ b/llnode.gypi
@@ -41,6 +41,15 @@
     "cflags": [
       "-std=c++11", "-fPIC",
     ],
+    "cflags_cc": [
+      "-Werror",
+      "-Wall",
+      "-Wextra",
+      "-Wendif-labels",
+      "-W",
+      "-Wno-unused-parameter",
+      "-Wundeclared-selector",
+    ],
     "xcode_settings": {
       "GCC_VERSION": "com.apple.compilers.llvm.clang.1_0",
       "GCC_WARN_ABOUT_MISSING_NEWLINE": "YES",  # -Wnewline-eof
@@ -51,7 +60,9 @@
         "-g",
       ],
       "WARNING_CFLAGS": [
+        "-Werror",
         "-Wall",
+        "-Wextra",
         "-Wendif-labels",
         "-W",
         "-Wno-unused-parameter",

--- a/llnode.gypi
+++ b/llnode.gypi
@@ -48,7 +48,6 @@
       "-Wendif-labels",
       "-W",
       "-Wno-unused-parameter",
-      "-Wundeclared-selector",
     ],
     "xcode_settings": {
       "GCC_VERSION": "com.apple.compilers.llvm.clang.1_0",

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -596,7 +596,7 @@ bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
 void FindReferencesCmd::ScanForReferences(ObjectScanner* scanner) {
   // Walk all the object instances and handle them according to their type.
   TypeRecordMap mapstoinstances = llscan_->GetMapsToInstances();
-  for (auto const entry : mapstoinstances) {
+  for (auto const& entry : mapstoinstances) {
     TypeRecord* typerecord = entry.second;
 
     for (uint64_t addr : typerecord->GetInstances()) {

--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -547,7 +547,8 @@ bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
      * - Objects that refer to a particular string literal.
      *   (lldb) findreferences -s "Hello World!"
      */
-    case ScanOptions::ScanType::kBadOption: {
+    case ScanOptions::ScanType::kBadOption:
+    default: {
       result.SetError("Invalid search type");
       result.SetStatus(eReturnStatusFailed);
       return false;

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -733,7 +733,7 @@ std::string Symbol::ToString(Error& err) {
     return "Symbol()";
   }
   HeapObject name = Name(err);
-  RETURN_IF_INVALID(name, "Symbol(???)");
+  RETURN_IF_INVALID(name, "Symbol(\?\?\?)");
   return "Symbol('" + String(name).ToString(err) + "')";
 }
 

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -511,7 +511,7 @@ std::string Printer::Stringify(v8::Map map, Error& err) {
     return std::string(tmp) + ":" +
            Stringify<v8::FixedArray>(descriptors, err) + ">";
   } else {
-    std::string(tmp) + ">";
+    return std::string(tmp) + ">";
   }
 }
 

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -365,7 +365,7 @@ std::string Printer::Stringify(v8::JSArrayBuffer js_array_buffer, Error& err) {
     } else {
       res += " [\n  ";
 
-      int display_length = std::min<int>(*byte_length, options_.length);
+      size_t display_length = std::min<size_t>(*byte_length, options_.length);
       res += llv8_->LoadBytes(*data, display_length, err);
 
       if (display_length < *byte_length) {
@@ -430,7 +430,7 @@ std::string Printer::Stringify(v8::JSTypedArray js_typed_array, Error& err) {
 
     res += " [\n  ";
 
-    int display_length = std::min<int>(*byte_length, options_.length);
+    size_t display_length = std::min<size_t>(*byte_length, options_.length);
     res += llv8_->LoadBytes(*data + *byte_offset, display_length, err);
 
     if (display_length < *byte_length) {

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -648,8 +648,9 @@ function verifyInvalidExpr(t, sess) {
     if (err) {
       return teardown(t, sess, err);
     }
-    t.ok(
-      /error: error: use of undeclared identifier 'invalid_expr'/.test(line),
+
+    t.ok(/^error: error: /.test(line)
+        && / use of undeclared identifier 'invalid_expr'$/.test(line),
       'invalid expression should return an error'
     );
     teardown(t, sess);

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -26,8 +26,8 @@ function testFindrefsForInvalidExpr(t, sess, next) {
   sess.send('v8 findrefs invalid_expr');
   sess.waitError(/error:/, (err, line) => {
     t.error(err);
-    t.ok(
-      /error: error: use of undeclared identifier 'invalid_expr'/.test(line),
+    t.ok(/^error: error: /.test(line)
+        && / use of undeclared identifier 'invalid_expr'$/.test(line),
       'invalid expression should return an error'
     );
     next();


### PR DESCRIPTION
When compiling with gcc-10.2.0 there are some warnings emitted.

The unit tests were failing when using gdb-9.2 and lldb-10.0.1 as the line would change from
```code
error: error: use of undeclared identifier 'invalid_expr'
```
to
```code
error: error: <user expression 3>:1:1: use of undeclared identifier 'invalid_expr'
```
This relaxes the test just enough to also work with older versions of gdb & lldb where this location information would not be included.