### PR TITLE
Update Ubuntu install instructions for 20.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ version is LLDB 3.9 and above.
   - You can install the lldb package using the package manager of your
     distribution. You may need to install additional packages for `liblldb`
     as well.
-  - For example, on Ubuntu 16.04 you can install the prerequisites with
+  - For example, on Ubuntu 20.04 you can install the prerequisites with
 
     ```bash
-    apt-get install lldb-4.0 liblldb-4.0-dev
+    apt-get install lldb liblldb-dev
     ```
 - FreeBSD
 


### PR DESCRIPTION
Instructions to install `lldb` and other dependencies do not work on Ubuntu 20.04 (latest LTS).

```
liam@sleeper:~$ sudo apt-get install lldb-4.0 liblldb-4.0-dev                                                                                                                                              
[sudo] password for liam:                                                                                                                                                                                  
Reading package lists... Done                                                                                                                                                                              
Building dependency tree                                                                                                                                                                                   
Reading state information... Done                                                                                                                                                                          
E: Unable to locate package lldb-4.0                                                                                                                                                                       
E: Couldn't find any package by glob 'lldb-4.0'                                                                                                                                                            
E: Couldn't find any package by regex 'lldb-4.0'                                                                                                                                                           
E: Unable to locate package liblldb-4.0-dev                                                                                                                                                                
E: Couldn't find any package by glob 'liblldb-4.0-dev'                                                                                                                                                     
E: Couldn't find any package by regex 'liblldb-4.0-dev'
```

Removing the version from `lldb` and `liblldb-dev` worked.
```
liam@sleeper:~$ sudo apt-get install lldb liblldb-dev                                                                                                                                                      
Reading package lists... Done                                                                                                                                                                              
Building dependency tree                                                                                                                                                                                   
Reading state information... Done                                                                                                                                                                          
The following additional packages will be installed:                                                                                                                                                       
  liblldb-10 liblldb-10-dev lldb-10 python3-lldb-10                                                                                                                                                        
The following NEW packages will be installed:                                                                                                                                                              
  liblldb-10 liblldb-10-dev liblldb-dev lldb lldb-10 python3-lldb-10                                                                                                                                       
0 to upgrade, 6 to newly install, 0 to remove and 0 not to upgrade.                                                                                                                                        
Need to get 4,824 kB of archives.                                                                                                                                                                          
After this operation, 22.6 MB of additional disk space will be used.                                                                                                                                       
Do you want to continue? [Y/n]
```

`lldb` and `liblldb-dev` are official Ubuntu packages now, seems specifying like this will install the latest stable release of each package.
https://packages.ubuntu.com/focal/lldb
https://packages.ubuntu.com/focal/liblldb-dev