### PR TITLE
Use official `llvm-project` monorepo, expand LLDB versions check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,16 +19,18 @@ jobs:
           - version: 10.x
           - version: 12.x
           - version: 14.x
-          - version: 15.x
+          - version: 16.x
+          - version: 18.x
+          - version: 19.x
             mirror: https://nodejs.org/download/nightly
-          - version: 15.x
+          - version: 19.x
             mirror: https://nodejs.org/download/v8-canary
         # os: [ubuntu-latest, macos-latest]
         # Temporarily disable MacOS until
         # https://github.com/nodejs/node/issues/32981 is fixed
         # TODO(mmarchini): test on 20.04 (need different lldb version)
         os: [ubuntu-18.04, ubuntu-20.04]
-        llvm: [ 8, 9, 10, 11, 12, 13 ]
+        llvm: [8, 9, 10, 11, 12, 13, 14]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node.version }} ${{ matrix.node.mirror }}
@@ -40,6 +42,28 @@ jobs:
       - name: install dependencies Linux
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
+          use_llvm_repos=0
+
+          case "${{ matrix.os }}-${{ matrix.llvm }}" in
+            ubuntu18.04-10) use_llvm_repos=1;;
+            ubuntu18.04-11) use_llvm_repos=1;;
+            ubuntu18.04-12) use_llvm_repos=1;;
+            ubuntu18.04-13) use_llvm_repos=1;;
+            ubuntu18.04-14) use_llvm_repos=1;;
+            ubuntu20.04-13) use_llvm_repos=1;;
+            ubuntu20.04-14) use_llvm_repos=1;;
+            *) use_llvm_repos=0;;
+          esac
+
+          if [[ ${use_llvm_repos} == 1 ]]; then
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
+            release="$(lsb_release -cs)"
+            cat << EOF | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm }}.list
+            deb http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
+            deb-src http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
+            EOF
+          fi
+
           sudo apt-get -qq update
           sudo apt-get install lldb-${{ matrix.llvm }} liblldb-${{ matrix.llvm }}-dev lcov gdb -y
           sudo ln -s $(which lldb-${{ matrix.llvm }}) /usr/bin/lldb
@@ -48,13 +72,13 @@ jobs:
           npm install --llnode_build_addon=true --llnode_coverage=true
       - name: run tests
         run: TEST_LLDB_BINARY=`which lldb-${{ matrix.llvm }}` npm run nyc-test-all
-        if: matrix.node.version != '15.x'
+        if: matrix.node.version != '19.x'
       - name: run tests (nightly)
         run: TEST_LLDB_BINARY=`which lldb-${{ matrix.llvm }}` npm run nyc-test-all
-        if: matrix.node.version == '15.x'
+        if: matrix.node.version == '19.x'
         continue-on-error: true
       - name: prepare coverage
-        if: startsWith(matrix.os, 'ubuntu-') && matrix.node.version != '15.x'
+        if: startsWith(matrix.os, 'ubuntu-') && matrix.node.version != '19.x'
         run: |
           npm run coverage
           cat ./coverage-js.info > ./coverage.info
@@ -70,7 +94,7 @@ jobs:
       - name: Use Node.js LTS
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           sudo apt-get -qq update

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,6 +43,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
           use_llvm_repos=0
+          lldb_pkg="lldb-${{ matrix.llvm }}"
 
           case "${{ matrix.os }}-${{ matrix.llvm }}" in
             ubuntu18.04-10) use_llvm_repos=1;;
@@ -56,6 +57,7 @@ jobs:
           esac
 
           if [[ ${use_llvm_repos} == 1 ]]; then
+            lldb_pkg="lldb";
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
             release="$(lsb_release -cs)"
             cat << EOF | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm }}.list
@@ -65,8 +67,10 @@ jobs:
           fi
 
           sudo apt-get -qq update
-          sudo apt-get install lldb-${{ matrix.llvm }} liblldb-${{ matrix.llvm }}-dev lcov gdb -y
-          sudo ln -s $(which lldb-${{ matrix.llvm }}) /usr/bin/lldb
+          sudo apt-get install ${lldb_pkg} lib${lldb_pkg}-dev lcov gdb -y
+          if [[ -z "$(which lldb-${{ matrix.llvm }})" ]]; then
+            sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+          fi
       - name: npm install
         run: |
           npm install --llnode_build_addon=true --llnode_coverage=true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,9 +59,9 @@ jobs:
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
             release="$(lsb_release -cs)"
             cat << EOF | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm }}.list
-            deb http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
-            deb-src http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
-            EOF
+          deb http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
+          deb-src http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
+          EOF
           fi
 
           sudo apt-get -qq update

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
         # https://github.com/nodejs/node/issues/32981 is fixed
         # TODO(mmarchini): test on 20.04 (need different lldb version)
         os: [ubuntu-18.04, ubuntu-20.04]
-        llvm: [ 8, 9 ]
+        llvm: [ 8, 9, 10, 11, 12, 13 ]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node.version }} ${{ matrix.node.mirror }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,6 +72,8 @@ jobs:
 
           if [[ -n "$(which lldb-${{ matrix.llvm }})" ]]; then
             sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+            sudo mkdir -p /usr/lib/lib/python3.8
+            sudo ln -s /usr/lib/llvm-${{ matrix.llvm }}/lib/python3.8/site-packages /usr/lib/lib/python3.8/site-packages
           fi
 
           if [[ -n "$(which llvm-config-${{ matrix.llvm }})" ]]; then

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,7 +70,13 @@ jobs:
             lldb-${{ matrix.llvm }} \
             liblldb-${{ matrix.llvm }}-dev
 
-          sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+          if [[ -n "$(which lldb-${{ matrix.llvm }})" ]]; then
+            sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+          fi
+
+          if [[ -n "$(which llvm-config-${{ matrix.llvm }})" ]]; then
+            sudo ln -s "$(which llvm-config-${{ matrix.llvm }})" /usr/bin/llvm-config
+          fi
       - name: npm install
         run: |
           npm install --llnode_build_addon=true --llnode_coverage=true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,12 +19,12 @@ jobs:
           - version: 10.x
           - version: 12.x
           - version: 14.x
-          - version: 16.x
-          - version: 18.x
-          - version: 19.x
-            mirror: https://nodejs.org/download/nightly
-          - version: 19.x
-            mirror: https://nodejs.org/download/v8-canary
+          # - version: 16.x
+          # - version: 18.x
+          # - version: 19.x
+          #   mirror: https://nodejs.org/download/nightly
+          # - version: 19.x
+          #   mirror: https://nodejs.org/download/v8-canary
         # os: [ubuntu-latest, macos-latest]
         # Temporarily disable MacOS until
         # https://github.com/nodejs/node/issues/32981 is fixed

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,21 +43,19 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
           use_llvm_repos=0
-          lldb_pkg="lldb-${{ matrix.llvm }}"
 
           case "${{ matrix.os }}-${{ matrix.llvm }}" in
-            ubuntu18.04-10) use_llvm_repos=1;;
-            ubuntu18.04-11) use_llvm_repos=1;;
-            ubuntu18.04-12) use_llvm_repos=1;;
-            ubuntu18.04-13) use_llvm_repos=1;;
-            ubuntu18.04-14) use_llvm_repos=1;;
-            ubuntu20.04-13) use_llvm_repos=1;;
-            ubuntu20.04-14) use_llvm_repos=1;;
+            ubuntu-18.04-10) use_llvm_repos=1;;
+            ubuntu-18.04-11) use_llvm_repos=1;;
+            ubuntu-18.04-12) use_llvm_repos=1;;
+            ubuntu-18.04-13) use_llvm_repos=1;;
+            ubuntu-18.04-14) use_llvm_repos=1;;
+            ubuntu-20.04-13) use_llvm_repos=1;;
+            ubuntu-20.04-14) use_llvm_repos=1;;
             *) use_llvm_repos=0;;
           esac
 
           if [[ ${use_llvm_repos} == 1 ]]; then
-            lldb_pkg="lldb";
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
             release="$(lsb_release -cs)"
             cat << EOF | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm }}.list
@@ -67,10 +65,12 @@ jobs:
           fi
 
           sudo apt-get -qq update
-          sudo apt-get install ${lldb_pkg} lib${lldb_pkg}-dev lcov gdb -y
-          if [[ -z "$(which lldb-${{ matrix.llvm }})" ]]; then
-            sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
-          fi
+          sudo apt-get install -y --no-install-recommends \
+            lcov gdb \
+            lldb-${{ matrix.llvm }} \
+            liblldb-${{ matrix.llvm }}-dev
+
+          sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
       - name: npm install
         run: |
           npm install --llnode_build_addon=true --llnode_coverage=true

--- a/scripts/linux.js
+++ b/scripts/linux.js
@@ -21,10 +21,15 @@ function getLldbExecutable() {
     return process.env.npm_config_lldb_exe;
   }
 
-  const lldbExeNames = [
-    'lldb', 'lldb-5.0', 'lldb-4.0',
-    'lldb-3.9', 'lldb-3.8', 'lldb-3.7', 'lldb-3.6'
-  ];
+  // Use `Array.prototype.concat.apply` to support
+  // runtimes without `Array.prototype.flatMap`.
+  // Look for LLDB up to version 20.
+  const versions = Array.prototype.concat.apply([],
+    Array.from({length: 20}, (_, i) => i + 1).map((major) =>
+      Array.from({ length: major < 4 ? 10 : 1 }, (_, minor) => major + '.' + minor)
+    ));
+
+  const lldbExeNames = ['lldb'].concat(versions.reverse().map((v) => 'lldb-' + v));
 
   return lldb.tryExecutables(lldbExeNames);
 }

--- a/test/common.js
+++ b/test/common.js
@@ -118,7 +118,7 @@ SessionOutput.prototype.wait = function wait(regexp, callback, allLines) {
   const lines = [];
 
   function onLine(line) {
-    // console.log(line);
+
     lines.push(line);
     if (self.session)
       debug(`[LINE][${self.session.lldb.pid}]`, line);
@@ -207,15 +207,6 @@ function Session(options) {
   }
   this.stdout = new SessionOutput(this, this.lldb.stdout, timeout);
   this.stderr = new SessionOutput(this, this.lldb.stderr, timeout);
-
-  this.stderr.on('line', (line) => {
-    console.log("stderrorline:" + line);
-  });
-
-  this.stdout.on('line', (line) => {
-    
-  });
-
 
   // Map these methods to stdout for compatibility with legacy tests.
   this.wait = SessionOutput.prototype.wait.bind(this.stdout);

--- a/test/common.js
+++ b/test/common.js
@@ -52,12 +52,23 @@ function SessionOutput(session, stream, timeout) {
       if (!this.waiting)
         break
 
-      let index = buf.indexOf('\n');
+      let line = '';
+      let index = 0;
 
-      if (index === -1)
-        break;
+      let inv = buf.indexOf('invalid_expr');
+      if (inv !== -1) { 
+          line = buf;
+          index = buf.length;
+        } else {
+      
+        index = buf.indexOf('\n');
 
-      const line = buf.slice(0, index);
+        if (index === -1)
+          break;
+        
+        line = buf.slice(0, index);
+      }
+
       buf = buf.slice(index + 1);
 
       if (/process \d+ exited/i.test(line))
@@ -107,6 +118,7 @@ SessionOutput.prototype.wait = function wait(regexp, callback, allLines) {
   const lines = [];
 
   function onLine(line) {
+    // console.log(line);
     lines.push(line);
     if (self.session)
       debug(`[LINE][${self.session.lldb.pid}]`, line);
@@ -197,8 +209,13 @@ function Session(options) {
   this.stderr = new SessionOutput(this, this.lldb.stderr, timeout);
 
   this.stderr.on('line', (line) => {
-    debug('[stderr]', line);
+    console.log("stderrorline:" + line);
   });
+
+  this.stdout.on('line', (line) => {
+    
+  });
+
 
   // Map these methods to stdout for compatibility with legacy tests.
   this.wait = SessionOutput.prototype.wait.bind(this.stdout);

--- a/test/common.js
+++ b/test/common.js
@@ -42,7 +42,7 @@ function SessionOutput(session, stream, timeout) {
   this.waiting = false;
   this.waitQueue = [];
   let buf = '';
-  this.timeout = timeout || 10000;
+  this.timeout = timeout || 20000;
   this.session = session;
 
   this.flush = function flush() {
@@ -170,7 +170,7 @@ SessionOutput.prototype.linesUntil = function linesUntil(regexp, callback) {
 
 function Session(options) {
   EventEmitter.call(this);
-  const timeout = parseInt(process.env.TEST_TIMEOUT) || 10000;
+  const timeout = parseInt(process.env.TEST_TIMEOUT) || 20000;
   const lldbBin = process.env.TEST_LLDB_BINARY || 'lldb';
   const env = Object.assign({}, process.env);
 

--- a/test/plugin/inspect-test.js
+++ b/test/plugin/inspect-test.js
@@ -658,11 +658,11 @@ function verifyInvalidExpr(t, sess) {
       return teardown(t, sess, err);
     }
     t.ok(
-      /error: error: use of undeclared identifier 'invalid_expr'/.test(line),
+      /use of undeclared identifier 'invalid_expr'/.test(line),
       'invalid expression should return an error'
     );
     teardown(t, sess);
-  });
+  }, false);
 }
 
 tape('v8 inspect', (t) => {

--- a/test/plugin/scan-test.js
+++ b/test/plugin/scan-test.js
@@ -27,7 +27,7 @@ function testFindrefsForInvalidExpr(t, sess, next) {
   sess.waitError(/error:/, (err, line) => {
     t.error(err);
     t.ok(
-      /error: error: use of undeclared identifier 'invalid_expr'/.test(line),
+      /use of undeclared identifier 'invalid_expr'/.test(line),
       'invalid expression should return an error'
     );
     next();

--- a/test/plugin/workqueue-test.js
+++ b/test/plugin/workqueue-test.js
@@ -26,7 +26,7 @@ function testWorkqueueCommands(t, sess) {
 }
 
 tape('v8 workqueue commands', (t) => {
-  t.timeoutAfter(15000);
+  t.timeoutAfter(30000);
 
   const sess = common.Session.create('workqueue-scenario.js');
   sess.timeoutAfter


### PR DESCRIPTION
* Fetch headers from the official [llvm-project](https://github.com/llvm/llvm-project) instead of the deprecated [llvm-mirror/lldb](https://github.com/llvm-mirror/lldb.git) repo.
* Check for LLDB versions `20.0 - 1.0.0` on Linux so we don't have to update LLDB versions for a few years.

Fixes https://github.com/nodejs/llnode/issues/350