### PR TITLE
src: fix warnings

### DIFF
--- a/src/llscan.cc
+++ b/src/llscan.cc
@@ -494,7 +494,7 @@ bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
     return false;
   }
 
-  ObjectScanner* scanner;
+  ObjectScanner* scanner = nullptr;
 
   switch (scan_options.scan_type) {
     case ScanOptions::ScanType::kFieldValue: {
@@ -596,7 +596,7 @@ bool FindReferencesCmd::DoExecute(SBDebugger d, char** cmd,
 void FindReferencesCmd::ScanForReferences(ObjectScanner* scanner) {
   // Walk all the object instances and handle them according to their type.
   TypeRecordMap mapstoinstances = llscan_->GetMapsToInstances();
-  for (auto const entry : mapstoinstances) {
+  for (auto const& entry : mapstoinstances) {
     TypeRecord* typerecord = entry.second;
 
     for (uint64_t addr : typerecord->GetInstances()) {

--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -119,14 +119,14 @@ double LLV8::LoadDouble(int64_t addr, Error& err) {
 }
 
 
-std::string LLV8::LoadBytes(int64_t addr, int64_t length, Error& err) {
+std::string LLV8::LoadBytes(int64_t addr, size_t length, Error& err) {
   uint8_t* buf = new uint8_t[length + 1];
   SBError sberr;
-  process_.ReadMemory(addr, buf, static_cast<size_t>(length), sberr);
+  process_.ReadMemory(addr, buf, length, sberr);
   if (sberr.Fail()) {
     err = Error::Failure(
         "Failed to load v8 backing store memory, "
-        "addr=0x%016" PRIx64 ", length=%" PRId64,
+        "addr=0x%016" PRIx64 ", length=%zu",
         addr, length);
     delete[] buf;
     return std::string();
@@ -134,7 +134,7 @@ std::string LLV8::LoadBytes(int64_t addr, int64_t length, Error& err) {
 
   std::string res;
   char tmp[10];
-  for (int i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     snprintf(tmp, sizeof(tmp), "%s%02x", (i == 0 ? "" : ", "), buf[i]);
     res += tmp;
   }
@@ -732,7 +732,8 @@ std::string Symbol::ToString(Error& err) {
     return "Symbol()";
   }
   HeapObject name = Name(err);
-  RETURN_IF_INVALID(name, "Symbol(???)");
+  // Use \? so we don't treat this as a trigraph.
+  RETURN_IF_INVALID(name, "Symbol(\?\?\?)");
   return "Symbol('" + String(name).ToString(err) + "')";
 }
 

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -669,7 +669,7 @@ class LLV8 {
   inline CheckedType<T> LoadUnsigned(int64_t addr, uint32_t byte_size);
   int64_t LoadUnsigned(int64_t addr, uint32_t byte_size, Error& err);
   double LoadDouble(int64_t addr, Error& err);
-  std::string LoadBytes(int64_t addr, int64_t length, Error& err);
+  std::string LoadBytes(int64_t addr, size_t length, Error& err);
   std::string LoadString(int64_t addr, int64_t length, Error& err);
   std::string LoadTwoByteString(int64_t addr, int64_t length, Error& err);
   uint8_t* LoadChunk(int64_t addr, int64_t length, Error& err);

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -365,7 +365,7 @@ std::string Printer::Stringify(v8::JSArrayBuffer js_array_buffer, Error& err) {
     } else {
       res += " [\n  ";
 
-      int display_length = std::min<int>(*byte_length, options_.length);
+      size_t display_length = std::min<size_t>(*byte_length, options_.length);
       res += llv8_->LoadBytes(*data, display_length, err);
 
       if (display_length < *byte_length) {
@@ -430,7 +430,7 @@ std::string Printer::Stringify(v8::JSTypedArray js_typed_array, Error& err) {
 
     res += " [\n  ";
 
-    int display_length = std::min<int>(*byte_length, options_.length);
+    size_t display_length = std::min<size_t>(*byte_length, options_.length);
     res += llv8_->LoadBytes(*data + *byte_offset, display_length, err);
 
     if (display_length < *byte_length) {
@@ -511,7 +511,7 @@ std::string Printer::Stringify(v8::Map map, Error& err) {
     return std::string(tmp) + ":" +
            Stringify<v8::FixedArray>(descriptors, err) + ">";
   } else {
-    std::string(tmp) + ">";
+    return std::string(tmp) + ">";
   }
 }
 


### PR DESCRIPTION
Fix various warnings which show up when compiling with gcc. For the most part this doesn't change any semantics -- the only user-facing change is a bug fix in `Printer::Stringify` caused by a missing `return`.