### PR TITLE
src: remove unboxed double support completely

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -133,17 +133,8 @@ void Map::Load() {
     kNumberOfOwnDescriptorsMask = (1 << kDescriptorIndexBitCount) - 1;
     kNumberOfOwnDescriptorsMask <<= kNumberOfOwnDescriptorsShift;
   }
-  kLayoutDescriptor =
-      LoadConstant({"class_Map__layout_descriptor__LayoutDescriptor"});
 }
 
-
-bool Map::HasUnboxedDoubleFields() {
-  // V8 has now disabled unboxed doubles in all supported Node.js branches. Per
-  // the V8 authors (v8/v8@42409a2e) it seems unlikely this support will ever
-  // return, so we could probably just remove it entirely.
-  return false;
-}
 
 void JSObject::Load() {
   kPropertiesOffset =

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -77,7 +77,6 @@ class Map : public Module {
   int64_t kInObjectPropertiesStartOffset;
   int64_t kInstanceSizeOffset;
   int64_t kInstanceTypeOffset;
-  Constant<int64_t> kLayoutDescriptor;
 
   int64_t kNumberOfOwnDescriptorsMask;
   int64_t kNumberOfOwnDescriptorsShift;

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -406,20 +406,6 @@ inline HeapNumber JSObject::GetDoubleField(int64_t index, Error err) {
 
   // TODO(mmarchini): Explain why index might be lower than zero.
   if (index < 0) {
-    // When unboxed doubles are not allowed, all double fields are stored as
-    // HeapNumber objects.
-    if (v8()->map()->HasUnboxedDoubleFields()) {
-      // TODO(mmarchini): GetInObjectValue call chain should be
-      // CheckedType-aware instead of relying on Error.
-      Error get_in_object_value_err;
-      double result = GetInObjectValue<double>(instance_size, index,
-                                               get_in_object_value_err);
-      if (get_in_object_value_err.Fail()) {
-        return HeapNumber(v8(), CheckedType<double>());
-      } else {
-        return HeapNumber(v8(), CheckedType<double>(result));
-      }
-    }
     return GetInObjectValue<HeapNumber>(instance_size, index, err);
   }
   HeapObject extra_properties_obj = Properties(err);


### PR DESCRIPTION
After #404, we no longer support unboxed doubles. Let's remove the relevant code.