### PR TITLE
remove more code used to support old Node.js versions

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -379,17 +379,9 @@ void JSArrayBuffer::Load() {
       LoadConstant({"class_JSArrayBuffer__byte_length__Object",
                     "class_JSArrayBuffer__byte_length__size_t"});
 
-  if (kBackingStoreOffset.Check()) {
-  }
-
-  kWasNeuteredMask = LoadConstant("jsarray_buffer_was_neutered_mask");
-  kWasNeuteredShift = LoadConstant("jsarray_buffer_was_neutered_shift");
-
-  if (kWasNeuteredMask == -1) {
-    // TODO(indutny): check V8 version?
-    kWasNeuteredMask = 1 << 3;
-    kWasNeuteredShift = 3;
-  }
+  // TODO: This should use postmortem data.
+  kWasNeuteredMask = 1 << 3;
+  kWasNeuteredShift = 3;
 }
 
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -519,8 +519,6 @@ void Frame::Load() {
   kExitFrame = LoadConstant("frametype_ExitFrame");
   kInternalFrame = LoadConstant("frametype_InternalFrame");
   kConstructFrame = LoadConstant("frametype_ConstructFrame");
-  // NOTE: The JavaScript frame type was removed in V8 6.3.158.
-  kJSFrame = LoadConstant("frametype_JavaScriptFrame");
   kOptimizedFrame = LoadConstant("frametype_OptimizedFrame");
   kStubFrame = LoadConstant("frametype_StubFrame");
 }

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -201,7 +201,6 @@ void SharedInfo::Load() {
   kInferredNameOffset =
       LoadConstant("class_SharedFunctionInfo__inferred_name__String",
                    "class_SharedFunctionInfo__function_identifier__Object");
-  kScriptOffset = LoadConstant("class_SharedFunctionInfo__script__Object");
   kScriptOrDebugInfoOffset = LoadConstant(
       {"class_SharedFunctionInfo__script_or_debug_info__Object",
        "class_SharedFunctionInfo__script_or_debug_info__HeapObject"});
@@ -221,18 +220,9 @@ void SharedInfo::Load() {
         "class_SharedFunctionInfo__formal_parameter_count__SMI");
   }
 
-  // NOTE: Could potentially be -1 on v4 and v5 node, should check in llv8
-  kScopeInfoOffset =
-      LoadConstant("class_SharedFunctionInfo__scope_info__ScopeInfo");
-
-  kStartPositionMask = LoadConstant("sharedfunctioninfo_start_position_mask");
-  kStartPositionShift = LoadConstant("sharedfunctioninfo_start_position_shift");
-
-  if (kStartPositionShift == -1) {
-    // TODO(indutny): check version?
-    kStartPositionShift = 2;
-    kStartPositionMask = ~((1 << kStartPositionShift) - 1);
-  }
+  // TODO: this should use postmortem data.
+  kStartPositionShift = 2;
+  kStartPositionMask = ~((1 << kStartPositionShift) - 1);
 
   if (LoadConstant("class_SharedFunctionInfo__compiler_hints__int") == -1 &&
       kNameOrScopeInfoOffset == -1)
@@ -260,8 +250,6 @@ void Code::Load() {
 
 void ScopeInfo::Load() {
   kParameterCountOffset = LoadConstant("scopeinfo_idx_nparams");
-  kStackLocalCountOffset = LoadConstant("scopeinfo_idx_nstacklocals");
-  kEmbeddedParamAndStackLocals = kStackLocalCountOffset != -1;
   kContextLocalCountOffset = LoadConstant("scopeinfo_idx_ncontextlocals");
   kVariablePartIndex = LoadConstant("scopeinfo_idx_first_vars");
   // Prior to Node.js v16, ScopeInfo inherited from FixedArray. In release

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -295,12 +295,7 @@ void String::Load() {
   kExternalStringTag = LoadConstant("ExternalStringTag");
   kThinStringTag = LoadConstant("ThinStringTag");
 
-  kLengthIsSmi = true;
-  kLengthOffset = LoadConstant("class_String__length__SMI");
-  if (kLengthOffset == -1) {
-    kLengthIsSmi = false;
-    kLengthOffset = LoadConstant("class_String__length__int32_t");
-  }
+  kLengthOffset = LoadConstant("class_String__length__int32_t");
 }
 
 

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -268,9 +268,6 @@ void Context::Load() {
   // of constants or a fallback list).
   kNativeIndex =
       LoadConstant("class_Context__native_index__int", "context_idx_native");
-  if (kNativeIndex == -1) {
-    kNativeIndex = LoadConstant("class_Context__native_context_index__int");
-  }
   kEmbedderDataIndex = LoadConstant("context_idx_embedder_data", (int)5);
 
   kMinContextSlots = LoadConstant("class_Context__min_context_slots__int",

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -81,14 +81,8 @@ void HeapObject::Load() {
 
 void Map::Load() {
   Error err;
-  kInstanceAttrsOffset = LoadConstant({"class_Map__instance_attributes__int",
-                                       "class_Map__instance_type__uint16_t"});
-  if (kInstanceAttrsOffset.name() ==
-      "v8dbg_class_Map__instance_type__uint16_t") {
-    kMapTypeMask = 0xffff;
-  } else {
-    kMapTypeMask = 0xff;
-  }
+  kInstanceAttrsOffset = LoadConstant({"class_Map__instance_type__uint16_t"});
+  kMapTypeMask = 0xffff;
 
   kMaybeConstructorOffset =
       LoadConstant("class_Map__constructor_or_backpointer__Object",

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -144,9 +144,6 @@ void JSObject::Load() {
       LoadConstant("class_JSReceiver__raw_properties_or_hash__Object",
                    "class_JSReceiver__properties__FixedArray");
 
-  if (kPropertiesOffset == -1)
-    kPropertiesOffset = LoadConstant("class_JSObject__properties__FixedArray");
-
   kElementsOffset = LoadConstant("class_JSObject__elements__Object");
   kInternalFieldsOffset =
       LoadConstant("class_JSObject__internal_fields__uintptr_t");

--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -312,22 +312,18 @@ void TwoByteString::Load() {
 
 
 void ConsString::Load() {
-  kFirstOffset = LoadConstant({"class_ConsString__first__String",
-                               "class_ConsString__first_offset__int"});
-  kSecondOffset = LoadConstant({"class_ConsString__second__String",
-                                "class_ConsString__second_offset__int"});
+  kFirstOffset = LoadConstant({"class_ConsString__first__String"});
+  kSecondOffset = LoadConstant({"class_ConsString__second__String"});
 }
 
 
 void SlicedString::Load() {
   kParentOffset = LoadConstant("class_SlicedString__parent__String");
-  kOffsetOffset = LoadConstant({"class_SlicedString__offset__SMI",
-                                "class_SlicedString__offset_offset__int"});
+  kOffsetOffset = LoadConstant({"class_SlicedString__offset__SMI"});
 }
 
 void ThinString::Load() {
-  kActualOffset = LoadConstant({"class_ThinString__actual__String",
-                                "class_ThinString__actual_offset__int"});
+  kActualOffset = LoadConstant({"class_ThinString__actual__String"});
 }
 
 void FixedArrayBase::Load() {

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -159,12 +159,10 @@ class SharedInfo : public Module {
   int64_t kNameOrScopeInfoOffset;
   int64_t kNameOffset;
   int64_t kInferredNameOffset;
-  int64_t kScriptOffset;
   Constant<int64_t> kScriptOrDebugInfoOffset;
   int64_t kStartPositionOffset;
   int64_t kEndPositionOffset;
   int64_t kParameterCountOffset;
-  int64_t kScopeInfoOffset;
   int64_t kFunctionDataOffset;
 
   int64_t kStartPositionMask;
@@ -203,9 +201,7 @@ class ScopeInfo : public Module {
   CONSTANTS_DEFAULT_METHODS(ScopeInfo);
 
   int64_t kParameterCountOffset;
-  int64_t kStackLocalCountOffset;
   int64_t kContextLocalCountOffset;
-  bool kEmbeddedParamAndStackLocals;
   int64_t kVariablePartIndex;
   bool kIsFixedArray;
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -495,7 +495,6 @@ class Frame : public Module {
   int64_t kExitFrame;
   int64_t kInternalFrame;
   int64_t kConstructFrame;
-  int64_t kJSFrame;
   int64_t kOptimizedFrame;
   int64_t kStubFrame;
 

--- a/src/llv8-constants.h
+++ b/src/llv8-constants.h
@@ -266,7 +266,6 @@ class String : public Module {
   int64_t kThinStringTag;
 
   int64_t kLengthOffset;
-  bool kLengthIsSmi;
 
  protected:
   void Load();

--- a/src/llv8-inl.h
+++ b/src/llv8-inl.h
@@ -470,13 +470,6 @@ inline int64_t String::Encoding(Error& err) {
 inline CheckedType<int32_t> String::Length(Error& err) {
   RETURN_IF_INVALID((*this), CheckedType<int32_t>());
 
-  if (v8()->string()->kLengthIsSmi) {
-    Smi len = LoadFieldValue<Smi>(v8()->string()->kLengthOffset, err);
-    RETURN_IF_INVALID(len, CheckedType<int32_t>());
-
-    return CheckedType<int32_t>(len.GetValue());
-  }
-
   CheckedType<int32_t> len = v8()->LoadValue<CheckedType<int32_t>>(
       LeaField(v8()->string()->kLengthOffset));
   RETURN_IF_INVALID(len, CheckedType<int32_t>());

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -217,11 +217,9 @@ class SharedFunctionInfo : public HeapObject {
 
  private:
   inline String name(Error& err);
-  inline Script script(Error& err);
   inline HeapObject script_or_debug_info(Error& err);
   inline Value inferred_name(Error& err);
   inline Value function_data(Error& err);
-  inline HeapObject scope_info(Error& err);
   inline HeapObject name_or_scope_info(Error& err);
 };
 
@@ -520,7 +518,6 @@ class ScopeInfo : public HeapObject {
   };
 
   inline Smi ParameterCount(Error& err);
-  inline Smi StackLocalCount(Error& err);
   inline Smi ContextLocalCount(Error& err);
   inline int ContextLocalIndex(Error& err);
   inline PositionInfo MaybePositionInfo(Error& err);

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -203,11 +203,6 @@ std::string Printer::Stringify(v8::FixedArray fixed_array, Error& err) {
 
 template <>
 std::string Printer::Stringify(v8::Context ctx, Error& err) {
-  // Not enough postmortem information, return bare minimum
-  if (llv8_->shared_info()->kScopeInfoOffset == -1 &&
-      llv8_->shared_info()->kNameOrScopeInfoOffset == -1)
-    return std::string();
-
   std::string res = "<Context";
 
   if (!options_.detailed) {

--- a/src/printer.cc
+++ b/src/printer.cc
@@ -49,8 +49,7 @@ std::string Printer::Stringify(v8::JSFrame js_frame, Error& err) {
       return "<constructor>";
     } else if (value == llv8_->frame()->kStubFrame) {
       return "<stub>";
-    } else if (value != llv8_->frame()->kJSFrame &&
-               value != llv8_->frame()->kOptimizedFrame) {
+    } else if (value != llv8_->frame()->kOptimizedFrame) {
       err = Error::Failure("Unknown frame marker %" PRId64, value);
       return std::string();
     }


### PR DESCRIPTION
This removes ~100 lines of code which were used to support old versions of Node.js. Doing this revealed some more places where we are missing postmortem metadata.

This is best reviewed commit-by-commit.