### PR TITLE
src: fix PropertyAttributesEnum_DONT_DELETE typo

### DIFF
--- a/src/llv8-constants.cc
+++ b/src/llv8-constants.cc
@@ -477,7 +477,7 @@ void DescriptorArray::Load() {
     kPropertyAttributesEnum_DONT_ENUM =
         LoadConstant("prop_attributes_DONT_ENUM");
     kPropertyAttributesEnum_DONT_DELETE =
-        LoadConstant("prop_attributes_DONT_ENUM");
+        LoadConstant("prop_attributes_DONT_DELETE");
 
     kPropertyKindMask = LoadConstant("prop_kind_mask");
     kPropertyKindEnum_kAccessor = LoadConstant("prop_kind_Accessor");


### PR DESCRIPTION
Frankly, this code is currently unused and it probably makes more sense to remove all of it entirely. But if we keep it, let's fix this typo I noticed.