### PR TITLE
src: don't crash on invalid script positions

### DIFF
--- a/src/llv8.cc
+++ b/src/llv8.cc
@@ -362,8 +362,15 @@ std::string JSFunction::GetSource(Error& err) {
   }
   int64_t len = end_pos - start_pos;
 
-  std::string res = source_str.substr(start_pos, len);
+  // Make sure the substr isn't out of range
+  if (start_pos < 0 || len < 0 || start_pos + len > source_len) {
+    err = Error::Failure("Invalid source range, start_pos=%" PRId64
+                         ", len=%" PRId64 ", source_len=%" PRId64,
+                         start_pos, len, source_len);
+    return std::string();
+  }
 
+  std::string res = source_str.substr(start_pos, len);
   return res;
 }
 


### PR DESCRIPTION
This "fixes" the segfault reported in #422, in the sense that you no longer get a segfault. However the printing does not actually work, i.e. you currently get an error like this:

```console
(lldb) v8 i -s 0x2196b1a09a29
error: Invalid source range, start_pos=3108, len=-3098, source_len=10
```

I'm deeming this better than segfaulting. We should really never be segfaulting as the coredump might be incomplete/partially corrupted. (Also, we already know function printing on v16 doesn't work right now.)