### PR TITLE
Support llvm dev releases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,7 +151,7 @@ jobs:
       - name: npm install, build, and test
         run: |
           sudo apt-get -qq update
-          sudo apt-get install lldb-6.0 liblldb-6.0-dev lcov -y
-          sudo ln -s $(which lldb-6.0) /usr/bin/lldb
+          sudo apt-get install lldb-11 liblldb-11-dev lcov -y
+          sudo ln -s $(which lldb-11) /usr/bin/lldb
           npm install
           npm run linter

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,9 +112,10 @@ jobs:
 
           if [[ -n "$(which lldb-${{ matrix.llvm }})" ]]; then
             sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+            python_version="$(python3 --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f3 --complement)";
             # Is `/usr/lib/lib` here correct?
-            sudo mkdir -p /usr/lib/lib/python3.8
-            sudo ln -s /usr/lib/llvm-${{ matrix.llvm }}/lib/python3.8/site-packages /usr/lib/lib/python3.8/site-packages
+            sudo mkdir -p /usr/lib/lib/python${python_version}
+            sudo ln -s /usr/lib/llvm-${{ matrix.llvm }}/lib/python${python_version}/site-packages /usr/lib/lib/python${python_version}/site-packages
           fi
 
           if [[ -n "$(which llvm-config-${{ matrix.llvm }})" ]]; then

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,9 @@
 name: on push or pull_request
 
+concurrency:
+  group: push-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -121,6 +121,9 @@ jobs:
           if [[ -n "$(which llvm-config-${{ matrix.llvm }})" ]]; then
             sudo ln -s "$(which llvm-config-${{ matrix.llvm }})" /usr/bin/llvm-config
           fi
+
+          echo "/usr/lib/llvm-${{ matrix.llvm }}/lib" | sudo tee /etc/ld.so.conf.d/llvm.conf
+          sudo ldconfig
       - name: npm install
         run: |
           npm install --llnode_build_addon=true --llnode_coverage=true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,11 +28,15 @@ jobs:
         # Temporarily disable MacOS until
         # https://github.com/nodejs/node/issues/32981 is fixed
         # TODO(mmarchini): test on 20.04 (need different lldb version)
-        os: [ubuntu-18.04, ubuntu-20.04]
-        llvm: [8, 9, 10, 11, 12, 13, 14]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        llvm: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
         exclude:
           # This errors due to a glibc incompatibility.
           - {os: ubuntu-18.04, node: {version: 18.x}}
+          # Neither LLVM nor Canonical package these versions for Jammy
+          - {os: ubuntu-22.04, llvm: 8}
+          - {os: ubuntu-22.04, llvm: 9}
+          - {os: ubuntu-22.04, llvm: 10}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node.version }} ${{ matrix.node.mirror }}
@@ -44,25 +48,59 @@ jobs:
       - name: install dependencies Linux
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
-          use_llvm_repos=0
+          use_llvm_repos=1
 
-          case "${{ matrix.os }}-${{ matrix.llvm }}" in
-            ubuntu-18.04-10) use_llvm_repos=1;;
-            ubuntu-18.04-11) use_llvm_repos=1;;
-            ubuntu-18.04-12) use_llvm_repos=1;;
-            ubuntu-18.04-13) use_llvm_repos=1;;
-            ubuntu-18.04-14) use_llvm_repos=1;;
-            ubuntu-20.04-13) use_llvm_repos=1;;
-            ubuntu-20.04-14) use_llvm_repos=1;;
-            *) use_llvm_repos=0;;
+          case "${{ matrix.os }}" in
+            ubuntu-18.04)
+              case "${{ matrix.llvm }}" in
+                8) use_llvm_repos=0;;
+                9) use_llvm_repos=0;;
+                10) use_llvm_repos=0;;
+                *) use_llvm_repos=1;;
+              esac
+              ;;
+            ubuntu-20.04)
+              case "${{ matrix.llvm }}" in
+                8) use_llvm_repos=0;;
+                9) use_llvm_repos=0;;
+                10) use_llvm_repos=0;;
+                11) use_llvm_repos=0;;
+                12) use_llvm_repos=0;;
+                *) use_llvm_repos=1;;
+              esac
+              ;;
+            ubuntu-22.04)
+              case "${{ matrix.llvm }}" in
+                11) use_llvm_repos=0;;
+                12) use_llvm_repos=0;;
+                13) use_llvm_repos=0;;
+                14) use_llvm_repos=0;;
+                15) use_llvm_repos=0;;
+                *) use_llvm_repos=1;;
+              esac
+              ;;
+            *) use_llvm_repos=1;;
           esac
 
           if [[ ${use_llvm_repos} == 1 ]]; then
+            llvm_suffix="-${{ matrix.llvm }}";
+            # If there's no `release/XY.x` branch, check if this is current dev release
+            if ! git ls-remote --exit-code --heads \
+                 https://github.com/llvm/llvm-project.git \
+                 refs/heads/release/${{ matrix.llvm }}.x >/dev/null 2>&1; then
+              # If there's an `llvmorg-XY-init` tag, this is the current dev release
+              if git ls-remote --exit-code --tags \
+                 https://github.com/llvm/llvm-project.git \
+                 refs/tags/llvmorg-${{ matrix.llvm }}-init >/dev/null 2>&1; then
+                # The dev release doesn't use a version suffix
+                llvm_suffix="";
+              fi
+            fi
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
             release="$(lsb_release -cs)"
-            cat << EOF | sudo tee /etc/apt/sources.list.d/llvm-${{ matrix.llvm }}.list
-          deb http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
-          deb-src http://apt.llvm.org/${release}/ llvm-toolchain-${release}-${{ matrix.llvm }} main
+            cat << EOF | sudo tee /etc/apt/sources.list.d/llvm${llvm_suffix}.list
+          deb http://apt.llvm.org/${release}/ llvm-toolchain-${release}${llvm_suffix} main
+          deb-src http://apt.llvm.org/${release}/ llvm-toolchain-${release}${llvm_suffix} main
           EOF
           fi
 
@@ -74,6 +112,7 @@ jobs:
 
           if [[ -n "$(which lldb-${{ matrix.llvm }})" ]]; then
             sudo ln -s "$(which lldb-${{ matrix.llvm }})" /usr/bin/lldb
+            # Is `/usr/lib/lib` here correct?
             sudo mkdir -p /usr/lib/lib/python3.8
             sudo ln -s /usr/lib/llvm-${{ matrix.llvm }}/lib/python3.8/site-packages /usr/lib/lib/python3.8/site-packages
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,7 @@ jobs:
           - version: 14.x
           - version: 16.x
           - version: 18.x
+          - version: 20.x
           # These error with "Unexpected input(s) 'node-mirror' ...":
           # - version: 19.x
           #   mirror: https://nodejs.org/download/nightly
@@ -28,11 +29,9 @@ jobs:
         # Temporarily disable MacOS until
         # https://github.com/nodejs/node/issues/32981 is fixed
         # TODO(mmarchini): test on 20.04 (need different lldb version)
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         llvm: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
         exclude:
-          # This errors due to a glibc incompatibility.
-          - {os: ubuntu-18.04, node: {version: 18.x}}
           # Neither LLVM nor Canonical package these versions for Jammy
           - {os: ubuntu-22.04, llvm: 8}
           - {os: ubuntu-22.04, llvm: 9}
@@ -51,14 +50,6 @@ jobs:
           use_llvm_repos=1
 
           case "${{ matrix.os }}" in
-            ubuntu-18.04)
-              case "${{ matrix.llvm }}" in
-                8) use_llvm_repos=0;;
-                9) use_llvm_repos=0;;
-                10) use_llvm_repos=0;;
-                *) use_llvm_repos=1;;
-              esac
-              ;;
             ubuntu-20.04)
               case "${{ matrix.llvm }}" in
                 8) use_llvm_repos=0;;

--- a/scripts/linux.js
+++ b/scripts/linux.js
@@ -23,9 +23,9 @@ function getLldbExecutable() {
 
   // Use `Array.prototype.concat.apply` to support
   // runtimes without `Array.prototype.flatMap`.
-  // Look for LLDB up to version 20.
+  // Look for LLDB up to version 99.
   const versions = Array.prototype.concat.apply([],
-    Array.from({length: 20}, (_, i) => i + 1).map((major) =>
+    Array.from({length: 99}, (_, i) => i + 1).map((major) =>
       Array.from({ length: major < 4 ? 10 : 1 }, (_, minor) => major + '.' + minor)
     ));
 


### PR DESCRIPTION
This is a followup to https://github.com/nodejs/llnode/pull/389:

* Updates the range of LLVM versions we check (from 20, which is next dev version, to 99)
* Support downloading headers if the detected `lldb` version is the current dev release
    * i.e. doesn't have a `release/XY.x` branch, but does have a `llvmorg-XY-init` tag
* Update the PR action to test ubuntu-22.04 + LLVM versions up to current dev (v19)

If we wanted to be fancy, we could populate the supported versions and CI matrix by parsing `git ls-remote --tags https://github.com/llvm/llvm-project.git 'refs/tags/llvmorg-*-init'`.

Let me know if that's something you'd like me to add!